### PR TITLE
Add `sheet.getStyleElement()` to the demo

### DIFF
--- a/components/advanced/server-side-rendering.js
+++ b/components/advanced/server-side-rendering.js
@@ -11,7 +11,7 @@ import { ServerStyleSheet } from 'styled-components'
 
 const sheet = new ServerStyleSheet()
 const html = renderToString(sheet.collectStyles(<YourApp />))
-const css = sheet.getStyleTags()
+const css = sheet.getStyleTags() // or sheet.getStyleElement()
 `).trim()
 
 const managerSample = (`
@@ -25,7 +25,7 @@ const html = renderToString(
   </StyleSheetManager>
 )
 
-const css = sheet.getStyleTags()
+const css = sheet.getStyleTags() // or sheet.getStyleElement()
 `).trim()
 
 const ServerSideRendering = () => (


### PR DESCRIPTION
I just upgraded the SSR API to the latest RC. I couldn't figure out how to get the generated CSS into the `<head>` when using `ReactDOM.renderToStaticMarkup()` and was about to try PR'ing this exact same method. Would be good to document it somewhere 😁