### PR TITLE
reduce repaints on fixed sidebar

### DIFF
--- a/components/Navbar/Sidebar.js
+++ b/components/Navbar/Sidebar.js
@@ -6,6 +6,7 @@ import captureScroll from '../CaptureScroll'
 
 const Sidebar = styled.nav`
   position: fixed;
+  transform: translateZ(0);
   display: block;
   z-index: 1;
 


### PR DESCRIPTION
`position: fixed` causes the sidebar to get repainted on the CPU with every scroll event, small hack to delegate this to the GPU.