### PR TITLE
#10 Resolved the scroll issue when changing breakpoints

### DIFF
--- a/components/CaptureScroll.js
+++ b/components/CaptureScroll.js
@@ -61,13 +61,24 @@ const captureScroll = Component => {
       }
     }
 
+    onResize = evt => {
+      isMobile = window.matchMedia(`(max-width: ${1000 / 16}em)`).matches
+      if(isMobile) {
+        this.node.removeEventListener('wheel', this.onScroll)
+      } else {
+        this.node.addEventListener('wheel', this.onScroll)
+      }
+    }
+
     componentDidMount() {
       this.node = findDOMNode(this.ref)
       this.node.addEventListener('wheel', this.onScroll)
+      window.addEventListener('resize', this.onResize)
     }
 
     componentWillUnmount() {
       this.node.removeEventListener('wheel', this.onScroll)
+      window.removeEventListener('resize', this.onResize)
     }
 
     render() {

--- a/components/Navbar/index.js
+++ b/components/Navbar/index.js
@@ -13,8 +13,14 @@ class Navbar extends Component {
   }
 
   onFold = () => {
+    let isFolded = !this.state.isFolded
+    if(!isFolded) {
+      document.body.classList.add('sticky')
+    } else {
+      document.body.classList.remove('sticky')
+    }
     this.setState({
-      isFolded: !this.state.isFolded
+      isFolded: isFolded
     })
   }
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -122,6 +122,10 @@ const resetStyles = `
     }
   }
 
+  body.sticky {
+    overflow: hidden;
+  }
+
   .root {
     position: relative;
     overflow: auto;


### PR DESCRIPTION
Hey @philpl—I've had a look at the issue, and you're right, it does appear to be the way you're managing scrolling.

I've added a couple of fixes, but keen to get your feedback on whether there's a more "styled-components" way of doing it. Especially when attaching classes to the body.

- Added a sticky class to the body when the navigation is expanded, which adds `overflow: hidden;`
- Added event listeners when loading on the desktop breakpoint, to trigger when resizing between desktop and mobile. This shouldn't impact mobile.

Happy to discuss.