### PR TITLE
Slightly fade out the logos on the homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -74,6 +74,11 @@ const CompanyLogo = styled.img`
   height: ${p => p.height || '2rem'};
   margin: 0.5rem;
   bottom: ${p => p.bottom || 0};
+  opacity: 0.6;
+
+  &:hover {
+    opacity: 1;
+  }
 `
 
 const Wrapper = styled.div`

--- a/pages/index.js
+++ b/pages/index.js
@@ -63,10 +63,11 @@ const UsersWrapper = styled.section`
 
 const UsersHeading = styled.p`
   text-transform: uppercase;
-  color: #000;
+  color: #fff;
   font-size: 0.8rem;
   font-weight: 600;
   margin: 2.5rem 0 0.5rem;
+  opacity: 0.8;
 `
 
 const CompanyLogo = styled.img`
@@ -74,7 +75,9 @@ const CompanyLogo = styled.img`
   height: ${p => p.height || '2rem'};
   margin: 0.5rem;
   bottom: ${p => p.bottom || 0};
-  opacity: 0.6;
+  opacity: 0.8;
+  filter: brightness(0) invert(1);
+  transition: opacity 125ms ease-in-out;
 
   &:hover {
     opacity: 1;


### PR DESCRIPTION
Before they would be the first thing that would hit your eye, which is
suboptimal as we've got a great tagline AND a live editor

Fixed that by making them `opacity: 0.6`, but I'm open to other
solutions. Making them white would be kinda awesome maybe? Any clues how
to do that?