### PR TITLE
drop pixels from input size

### DIFF
--- a/components/api/primary/styled.js
+++ b/components/api/primary/styled.js
@@ -27,7 +27,7 @@ import styled from 'styled-components';
 
 const Input = styled.input.attrs({
   type: 'text',
-  size: props => props.small ? '3px' : '8px'
+  size: props => props.small ? 3 : 8
 })\`
   background: palevioletred;
   border-radius: 3px;


### PR DESCRIPTION
Input sizes are [numbers](https://www.w3schools.com/tags/att_input_size.asp), I'm not sure if that was the intention but changing a pixel value makes it a little confusing.