### PR TITLE
fix typo under "Adding additional props" section

### DIFF
--- a/components/basics/attaching-additional-props.js
+++ b/components/basics/attaching-additional-props.js
@@ -59,8 +59,8 @@ const AttachingAdditionalProps = () => (
     />
 
     <p>
-      As you can see, we get access to our newly created props in the interpolations, and the <Code>type</Code>
-      attribute is passed down to the element.
+      As you can see, we get access to our newly created props in the interpolations, and
+      the <Code>type</Code> attribute is passed down to the element.
     </p>
 
 


### PR DESCRIPTION
Fix type attribute typo under "Adding additional props"

<img width="984" alt="screen shot 2017-05-28 at 1 09 08 pm" src="https://cloud.githubusercontent.com/assets/10946524/26530650/ddedcb72-43a6-11e7-885e-71d4ad1fba76.png">
