### PR TITLE
Add react-native note in styling-any-components

### DIFF
--- a/components/basics/styling-any-components.js
+++ b/components/basics/styling-any-components.js
@@ -33,6 +33,10 @@ const StylingAnyComponents = () => (
       components as well, as long as they're accepting the <Code>className</Code> prop.
     </p>
 
+    <Note>
+      If you are using <Code>react-native</Code> keep in mind to use <Code>style</Code> instead of <Code>className</Code>.
+    </Note>
+
     <p>
       If you're using any external library, you can consider using this pattern to turn them
       into styled components. The same pattern works for your own components as well, if you


### PR DESCRIPTION
(ref https://github.com/styled-components/styled-components/issues/858)

I added a note to use `style` instead of `className` for `react-native`.