### PR TITLE
Theme color that goes with the header

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -153,7 +153,7 @@ export default class MyDocument extends Document {
           <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
 
-          <meta name="theme-color" content="#db7093" />
+          <meta name="theme-color" content="#da936a" />
           <meta name="author" content="styled-components" />
           <meta name="description" content={description} />
 

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -30,6 +30,6 @@
   ],
   "start_url": "/",
   "display": "standalone",
-  "theme_color": "#db7093",
+  "theme_color": "#da936a",
   "background_color": "#ffffff"
 }


### PR DESCRIPTION
Use a theme color that goes well with the header.

Before & after: 

<img src="https://user-images.githubusercontent.com/1863771/27164719-c4435d7c-51ac-11e7-92f6-1c44804b77c1.png" width="300"/> <img src="https://user-images.githubusercontent.com/1863771/27164710-b7a52d0c-51ac-11e7-85b2-06814b5ba590.png" width="300"/>
