### PR TITLE
Add CSSTransitionGroup info

### DIFF
--- a/components/faqs/css-transition-group.js
+++ b/components/faqs/css-transition-group.js
@@ -3,6 +3,7 @@ import React from 'react'
 import SectionLayout from '../SectionLayout'
 import CodeBlock from '../CodeBlock'
 import Code from '../Code'
+import Note from '../Note';
 import { InlineLink } from '../Link'
 
 const sampleCssTransitionGroup = (`
@@ -57,6 +58,7 @@ const Nesting = () => (
     <p><InlineLink href="https://github.com/reactjs/react-transition-group"><Code>react-transition-group</Code></InlineLink> is a popular React package for animating components as they enter or leave.</p>
     <p><Code>CSSTransitionGroup</Code>, the high-level animation component exported by <Code>react-transition-group</Code>, works by applying class names to the components when they're transitioning; they leave the exact animation implementation up to you.</p>
     <p>We can use it with styled-components by using <Code>attrs</Code> to map the class names it expects to ones we define, and then defining styles for those class names:</p>
+    <Note>These instructions use v1 of <Code>react-transition-group</Code></Note>
     <CodeBlock code={sampleCssTransitionGroup} language="jsx" />
   </SectionLayout>
 )

--- a/components/faqs/css-transition-group.js
+++ b/components/faqs/css-transition-group.js
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import SectionLayout from '../SectionLayout'
+import CodeBlock from '../CodeBlock'
+import Code from '../Code'
+
+const sampleCssTransitionGroup = (`
+import {CSSTransitionGroup} from 'react-transition-group'
+
+// Define constants for all our class names and timeouts.
+// This is optional, but recommended.
+const enter = 'example-enter'
+const enterActive = 'example-enter-active'
+const leave = 'example-leave'
+const leaveActive = 'example-leave-active'
+const enterTimeout = 500
+const leaveTimeout = 500
+
+// Set the props that CSSTransitionGroup expects, including mapping its
+// desired class names to the ones we've defined.
+const ExampleTransitionGroup = styled(CSSTransitionGroup).attrs({
+  transitionName: { enter, enterActive, leave, leaveActive },
+  transitionEnterTimeout: enterTimeout,
+  transitionLeaveTimeout: leaveTimeout,
+})\`
+  .\${enter} {
+    transform: translateY(100%);
+  }
+
+  .\${enterActive} {
+    transform: translateY(0);
+    transition: transform \${enterTimeout}ms ease-in;
+  }
+
+  .\${leave} {
+    transform: translateY(0);
+  }
+
+  .\${leaveActive} {
+    transform: translateY(100%);
+    transition: transform \${leaveTimeout}ms ease-in;
+  }
+\`
+
+render(
+  <ExampleTransitionGroup>
+    <div key={1}>Thing 1</div>
+    <div key={2}>Thing 2</div>
+    <div key={3}>Thing 3</div>
+  </ExampleTransitionGroup>
+)
+`).trim()
+
+const Nesting = () => (
+  <SectionLayout title="Can I use CSSTransitionGroup?">
+    <p><a href="https://github.com/reactjs/react-transition-group"><Code>react-transition-group</Code></a> is a popular React package for animating components as they enter or leave.</p>
+    <p><Code>CSSTransitionGroup</Code>, the high-level animation component exported by react-transition-group, works by applying class names to the components when they're transitioning; they leave the exact animation implementation up to you.</p>
+    <p>We can use it with styled-components by using <Code>attrs</Code> to map the class names it expects to ones we define, and then defining styles for those class names:</p>
+    <CodeBlock code={sampleCssTransitionGroup} language="jsx" />
+  </SectionLayout>
+)
+
+export default Nesting

--- a/components/faqs/css-transition-group.js
+++ b/components/faqs/css-transition-group.js
@@ -3,6 +3,7 @@ import React from 'react'
 import SectionLayout from '../SectionLayout'
 import CodeBlock from '../CodeBlock'
 import Code from '../Code'
+import { InlineLink } from '../Link'
 
 const sampleCssTransitionGroup = (`
 import {CSSTransitionGroup} from 'react-transition-group'
@@ -53,8 +54,8 @@ render(
 
 const Nesting = () => (
   <SectionLayout title="Can I use CSSTransitionGroup?">
-    <p><a href="https://github.com/reactjs/react-transition-group"><Code>react-transition-group</Code></a> is a popular React package for animating components as they enter or leave.</p>
-    <p><Code>CSSTransitionGroup</Code>, the high-level animation component exported by react-transition-group, works by applying class names to the components when they're transitioning; they leave the exact animation implementation up to you.</p>
+    <p><InlineLink href="https://github.com/reactjs/react-transition-group"><Code>react-transition-group</Code></InlineLink> is a popular React package for animating components as they enter or leave.</p>
+    <p><Code>CSSTransitionGroup</Code>, the high-level animation component exported by <Code>react-transition-group</Code>, works by applying class names to the components when they're transitioning; they leave the exact animation implementation up to you.</p>
     <p>We can use it with styled-components by using <Code>attrs</Code> to map the class names it expects to ones we define, and then defining styles for those class names:</p>
     <CodeBlock code={sampleCssTransitionGroup} language="jsx" />
   </SectionLayout>

--- a/pages/docs.json
+++ b/pages/docs.json
@@ -93,7 +93,8 @@
       "sections": [
         { "title": "Can I nest rules?" },
         { "title": "Can I refer to other components?" },
-        { "title": "Can I use css frameworks?" }
+        { "title": "Can I use css frameworks?" },
+        { "title": "Can I use CSSTransitionGroup?" }
       ]
     }
   ]

--- a/pages/docs/faqs.js
+++ b/pages/docs/faqs.js
@@ -4,12 +4,14 @@ import DocsLayout from '../../components/DocsLayout'
 import Nesting from '../../components/faqs/nesting'
 import ReverseSelectors from '../../components/faqs/reverse-selectors'
 import CSSFrameworks from '../../components/faqs/support-for-css-frameworks'
+import CssTransitionGroup from '../../components/faqs/css-transition-group'
 
 const FAQs = () => (
   <DocsLayout title="FAQs">
     <Nesting />
     <ReverseSelectors />
     <CSSFrameworks />
+    <CssTransitionGroup />
   </DocsLayout>
 )
 


### PR DESCRIPTION
:wave: hi folks!

As discussed [on twitter](https://twitter.com/_philpl/status/881249767669583873), adding some documentation for integrating styled-components with CSSTransitionGroup.

Added this to the FAQ, but I'm not sure that that's the best place for it. Lemme know!

![screen shot 2017-07-08 at 11 46 36 am](https://user-images.githubusercontent.com/6692932/27986863-26f7e0fe-63d3-11e7-964d-428a5e8f6099.png)

