### PR TITLE
fix: more consistent example

### DIFF
--- a/components/advanced/server-side-rendering.js
+++ b/components/advanced/server-side-rendering.js
@@ -10,7 +10,7 @@ import { ServerStyleSheet } from 'styled-components'
 
 const sheet = new ServerStyleSheet()
 const html = renderToString(sheet.collectStyles(<YourApp />))
-const css = sheet.getStyleTags() // or sheet.getStyleElement()
+const styleTags = sheet.getStyleTags() // or sheet.getStyleElement()
 `).trim()
 
 const managerSample = (`
@@ -24,7 +24,7 @@ const html = renderToString(
   </StyleSheetManager>
 )
 
-const css = sheet.getStyleTags() // or sheet.getStyleElement()
+const styleTags = sheet.getStyleTags() // or sheet.getStyleElement()
 `).trim()
 
 const nextSample = (`


### PR DESCRIPTION
Just replaced `css` for `styleTags`, because `sheet.getStyleElement()` is really returning style tags, not plain css.