### PR TITLE
Show how to import keyframes helper

### DIFF
--- a/components/basics/animations.js
+++ b/components/basics/animations.js
@@ -37,8 +37,8 @@ const Animations = () => (
     </p>
 
     <p>
-      This way, you get all the benefits of using JavaScript, are avoiding name clashes and get your keyframes
-      like always:
+      To use it, <Code>import { keyframes } from 'styled-components'</Code>, generate your animation name with
+      <Code>keyframes</Code>, then inject that animation name into your styles:
     </p>
 
     <LiveEdit


### PR DESCRIPTION
The Basics page doesn't show `keyframes` being imported, leaving some ambiguity about where that helper comes from. It is `styled.keyframes`? `import 'styled-components/keyframes'`?  I've tried to clarify here.

Ideally the `import` statement would be in the live code sample, but I've settled for putting it in the preceding description.