### PR TITLE
Use fully qualified plugin name in Babel config

### DIFF
--- a/components/advanced/babel-plugin.js
+++ b/components/advanced/babel-plugin.js
@@ -5,20 +5,22 @@ import Code from '../Code';
 import Note from '../Note';
 import Link from '../Link'
 
+const pluginName = "babel-plugin-styled-components";
+
 const installNPM = `
-npm install --save-dev babel-plugin-styled-components
+npm install --save-dev ${pluginName}
 `.trim();
 
 const usage = `
 {
-  "plugins": ["styled-components"]
+  "plugins": ["${pluginName}"]
 }
 `.trim();
 
 const ssr = `
 {
   "plugins": [
-    ["styled-components", {
+    ["${pluginName}", {
       "ssr": true
     }]
   ]
@@ -28,7 +30,7 @@ const ssr = `
 const displayName = `
 {
   "plugins": [
-    ["styled-components", {
+    ["${pluginName}", {
       "displayName": false
     }]
   ]
@@ -38,7 +40,7 @@ const displayName = `
 const preprocess = `
 {
   "plugins": [
-    ["styled-components", {
+    ["${pluginName}", {
       "preprocess": true
     }]
   ]
@@ -48,7 +50,7 @@ const preprocess = `
 const minify = `
 {
   "plugins": [
-    ["styled-components", {
+    ["${pluginName}", {
       "minify": false
     }]
   ]
@@ -58,7 +60,7 @@ const minify = `
 const transpilation = `
 {
   "plugins": [
-    ["styled-components", {
+    ["${pluginName}", {
       "transpileTemplateLiterals": false
     }]
   ]


### PR DESCRIPTION
Using just "styled-components" can cause a hard-to-understand error
("Cannot create styled-component for component: [object Object]") if
the plugin hasn't actually been installed, since Babel tries to load
the styled-components module itself instead of the plugin. Fully
qualifying the plugin name ensures that a sensible error is thrown
if the plugin isn't present.