### PR TITLE
Integrate Google tag manager

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -177,18 +177,11 @@ export default class MyDocument extends Document {
 
           {styles}
 
-          <script dangerouslySetInnerHTML={{ __html: `
-            !function(s,t,y,l,e,d,c){s.GoogleAnalyticsObject=y;s[y]||(s[y]=function(){
-            (s[y].q=s[y].q||[]).push(arguments)});s[y].l=+new Date;d=t.createElement(l);
-            c=t.getElementsByTagName(l)[0];d.src=e;c.parentNode.insertBefore(d,c)}
-            (window,document,'ga','script','//www.google-analytics.com/analytics.js');
-
-            ga('create', 'UA-105613776-1', 'auto');
-            ga('send', 'pageview');
-            `}}></script>
+      <script dangerouslySetInnerHTML={{ __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-WDWNSLK');` }}></script>
        </Head>
 
        <body>
+      <noscript dangerouslySetInnerHTML={{ __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WDWNSLK" height="0" width="0" style="display:none;visibility:hidden"></iframe>` }}></noscript>
          <div className="root">
            <Main />
          </div>


### PR DESCRIPTION
My previous Google Analytics implementation wasn't working, only firing
on first visit. Google Tag Manager has the power to listen to history
changes and fire analytics events when they happen, so I've configured
Google Tag manager to do exactly that.

This means our analytics setup is now working perfectly and tracking
pageviews as it should.