### PR TITLE
Unblock first render by moving font link

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -176,8 +176,6 @@ export default class MyDocument extends Document {
           <meta name="theme-color" content="#da936a" />
           <meta name="author" content="styled-components" />
 
-          {/* cloud.typography */}
-          <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7039052/7606172/css/fonts.css" />
           <style dangerouslySetInnerHTML={{ __html: resetStyles }} />
 
           {styles}
@@ -192,6 +190,9 @@ export default class MyDocument extends Document {
          </div>
 
          <NextScript />
+
+         {/* cloud.typography */}
+         <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7039052/7606172/css/fonts.css" />
        </body>
      </html>
     )


### PR DESCRIPTION
Loading Operator Mono in the `<head>` meant we were blocking the first render by quite a long time. The font had to be completely loaded before the browser could construct the CSSOM, meaning until then nothing was happening making our perceived loading time a lot slower than it needed to be.

By moving the fonts `.css` file at the bottom of the `<body>` we have a first render before that font is loaded, making perceived performance a lot faster.

This does give us a FOUT (flash of unstyled text), BUT since it's only the font we use for code it's unnoticable and/or very small.

PageSpeed Insights before:

![screen shot 2017-10-06 at 10 00 55 am](https://user-images.githubusercontent.com/7525670/31268743-01839420-aa7e-11e7-88b8-4d68554f94d3.png)

PageSpeed Insights after:

![screen shot 2017-10-06 at 10 01 11 am](https://user-images.githubusercontent.com/7525670/31268746-0551d76a-aa7e-11e7-8ad2-3e48f1641c71.png)

Check out the FOUT on your own machine by going to this deploy: https://styled-components-docs-qldaglwxhk.now.sh