### PR TITLE
Docs for the `theme` prop

### DIFF
--- a/components/Code.js
+++ b/components/Code.js
@@ -10,6 +10,7 @@ const Code = styled.span`
   font-weight: 300;
   padding: 0 0.05em 0.1em;
   vertical-align: bottom;
+  line-height: 1.4;
 `
 
 export default Code

--- a/sections/advanced/theming.js
+++ b/sections/advanced/theming.js
@@ -41,7 +41,7 @@ const Theming = () => md`
 
       <ThemeProvider theme={theme}>
         <Button>Themed</Button>
-      </ThemeProvider>
+      </ThemeProvider>      
     </div>
   );
   \`\`\`
@@ -109,6 +109,45 @@ const Theming = () => md`
 
   export default withTheme(MyComponent)
   \`\`\`
+
+  ### The \`theme\` prop
+
+  A theme can also be passed down to a component using the \`theme\` prop.
+
+  This is useful to circumvent a missing \`ThemeProvider\` or to override it.
+
+  \`\`\`react
+  // Define our button
+  const Button = styled.button\`
+    font-size: 1em;
+    margin: 1em;
+    padding: 0.25em 1em;
+    border-radius: 3px;
+
+    /* Color the border and text with theme.main */
+    color: \${props => props.theme.main};
+    border: 2px solid \${props => props.theme.main};
+  \`;
+
+  // Define what main theme will look like
+  const theme = {
+    main: 'mediumseagreen'
+  };
+
+  render(
+    <div>
+      <Button theme={{ main: 'royalblue' }}>Ad hoc theme</Button>
+      <ThemeProvider theme={theme}>
+        <div>
+          <Button>Themed</Button>
+          <Button theme={{ main: 'darkorange' }}>Overidden</Button>
+        </div>
+      </ThemeProvider>      
+    </div>
+  );
+  \`\`\`
+
+  
 `
 
 export default Theming

--- a/sections/advanced/theming.js
+++ b/sections/advanced/theming.js
@@ -41,7 +41,7 @@ const Theming = () => md`
 
       <ThemeProvider theme={theme}>
         <Button>Themed</Button>
-      </ThemeProvider>      
+      </ThemeProvider>
     </div>
   );
   \`\`\`

--- a/test/components/__snapshots__/Code.spec.js.snap
+++ b/test/components/__snapshots__/Code.spec.js.snap
@@ -8,6 +8,7 @@ exports[`Code renders correctly 1`] = `
   font-weight: 300;
   padding: 0 0.05em 0.1em;
   vertical-align: bottom;
+  line-height: 1.4;
 }
 
 <span

--- a/test/pages/__snapshots__/index.spec.js.snap
+++ b/test/pages/__snapshots__/index.spec.js.snap
@@ -126,6 +126,7 @@ exports[`Index renders correctly 1`] = `
   font-weight: 300;
   padding: 0 0.05em 0.1em;
   vertical-align: bottom;
+  line-height: 1.4;
 }
 
 .c56 {

--- a/test/sections/__snapshots__/homepage-getting-started.spec.js.snap
+++ b/test/sections/__snapshots__/homepage-getting-started.spec.js.snap
@@ -8,6 +8,7 @@ exports[`HomepageGettingStarted renders correctly 1`] = `
   font-weight: 300;
   padding: 0 0.05em 0.1em;
   vertical-align: bottom;
+  line-height: 1.4;
 }
 
 .c16 {


### PR DESCRIPTION
Here's my attempt at https://github.com/styled-components/styled-components-website/issues/116.

I thought a bit about whether to add this info as part of the main theming section (the first one) or as a separate one and went for a separate one in the end, to keep the explanations from growing too much.
Did you have anything else in mind on where to put this?

Also, I didn't actually mention anything about the prop being reserved. Should I?

PS. You'll notice I changed the `line-height` of the code blocks - that's to keep the text in `monospace` font aligned with everything else in titles and content text. 

Looking forward to feedback & further instructions :) Thanks!