### PR TITLE
Fix elementToText and titleToDash (slugifiers)

### DIFF
--- a/utils/elementToText.js
+++ b/utils/elementToText.js
@@ -1,17 +1,20 @@
 import { isValidElement } from 'react'
 
+const whitespacesRe = /\s+/g
+const _format = str => str.replace(whitespacesRe, ' ')
+
 const elementToText = node => {
-  if (Array.isArray(node)) {
-    return node
-      .map(elementToText)
-      .join('')
-  } else if (isValidElement(node)) {
-    return elementToText(node.props.children).trim()
-  } else if (typeof node === 'string') {
-    return node.trim()
+  const rec = x => {
+    if (Array.isArray(x)) {
+      return node.map(rec).join('')
+    } else if (isValidElement(x)) {
+      return elementToText(x.props.children)
+    } else if (typeof x === 'string') {
+      return x
+    }
   }
 
-  return ''
+  return _format(rec(node))
 }
 
 export default elementToText

--- a/utils/titleToDash.js
+++ b/utils/titleToDash.js
@@ -3,9 +3,8 @@ import elementToText from './elementToText'
 const titleToDash = title => (
   elementToText(title)
     .toLowerCase()
-    .replace(/[^\w\d\s]/, '')
-    .split(' ')
-    .join('-')
+    .replace(/[^\w\d\s]/g, '')
+    .replace(/\s+/g, '-')
 )
 
 export default titleToDash


### PR DESCRIPTION
Fix #105

The following bugs were fixed:

- titleToDash would not remove all non-alphanumeric characters
- titleToDash would not take multiple whitespaces into account
- elementToText would not take trailing and leading whitespaces into
account
- elementToText would not normalise subsequent, multiple whitespaces

This should improve the behaviour of all slugification