### PR TITLE
Fix broken anchor links in SideBarMenu

### DIFF
--- a/utils/titleToDash.js
+++ b/utils/titleToDash.js
@@ -2,6 +2,7 @@ import elementToText from './elementToText'
 
 const titleToDash = title => (
   elementToText(title)
+    .trim()
     .toLowerCase()
     .replace(/[^\w\d\s]/g, '')
     .replace(/\s+/g, '-')


### PR DESCRIPTION
The sidebar links to https://www.styled-components.com/docs/advanced#server-side-rendering but the actual anchor in the doc itself was being rendered as https://www.styled-components.com/docs/advanced#server-side-rendering- (an extra dash at the end).

This is because the SSR heading has the ` | v2` tag appended, the string was being split on the pipe but the extra spaces weren't being trimmed.