### PR TITLE
Fixed typo in server-side-rendering.js

### DIFF
--- a/sections/advanced/server-side-rendering.js
+++ b/sections/advanced/server-side-rendering.js
@@ -86,7 +86,7 @@ const ServerSideRendering = () => md`
  
   You will need to use \`babel-plugin-styled-components\` to get this working. More details [here](https://www.npmjs.com/package/babel-plugin-styled-components)
   
-  Refer to [our example](https://github.com/zeit/next.js/tree/master/examples/with-styled-components) in the Next.js repo fro an up-to-date usage example.
+  Refer to [our example](https://github.com/zeit/next.js/tree/master/examples/with-styled-components) in the Next.js repo for an up-to-date usage example.
 `
 
 export default ServerSideRendering


### PR DESCRIPTION
Just patching up a little typo.
`in the Next.js repo fro` -> `in the Next.js repo for`