### PR TITLE
Fix sidebar links by trimming output of elementToText

### DIFF
--- a/test/utils/elementToText.spec.js
+++ b/test/utils/elementToText.spec.js
@@ -10,6 +10,10 @@ describe('elementToText', () => {
     expect(elementToText('a  b')).toBe('a b')
   })
 
+  it('trims a string', () => {
+    expect(elementToText('a ')).toBe('a')
+  })
+
   it('stringifies an array of strings', () => {
     expect(elementToText(['a ', ' b'])).toBe('a b')
   })

--- a/utils/elementToText.js
+++ b/utils/elementToText.js
@@ -15,6 +15,6 @@ const elementToTextRec = x => {
   return ''
 }
 
-const elementToText = node => _format(elementToTextRec(node))
+const elementToText = node => _format(elementToTextRec(node)).trim()
 
 export default elementToText

--- a/utils/elementToText.js
+++ b/utils/elementToText.js
@@ -1,7 +1,7 @@
 import { isValidElement } from 'react'
 
 const whitespacesRe = /\s+/g
-const _format = (str = '') => str.replace(whitespacesRe, ' ')
+const _format = (str = '') => str.trim().replace(whitespacesRe, ' ')
 
 const elementToTextRec = x => {
   if (Array.isArray(x)) {
@@ -15,6 +15,6 @@ const elementToTextRec = x => {
   return ''
 }
 
-const elementToText = node => _format(elementToTextRec(node)).trim()
+const elementToText = node => _format(elementToTextRec(node))
 
 export default elementToText


### PR DESCRIPTION
Sidebar was linking to https://www.styled-components.com/docs/advanced#server-side-rendering but the anchor in the doc itself rendered as https://www.styled-components.com/docs/advanced#server-side-rendering- (an extra dash at the end).

This was due to the heading having the tag ` | v2` appended, the string was being split on the pipe but the extra spaces weren't being trimmed.