### PR TITLE
Add link to snack demo

### DIFF
--- a/sections/basics/react-native.js
+++ b/sections/basics/react-native.js
@@ -3,12 +3,13 @@ import md from 'components/md'
 const ReactNative = () => md`
   ## React Native
 
-  styled-components can be used with React Native in the same way,
-  except you import it from \`styled-components/native\` instead.
+  styled-components can be used with React Native in the same way, except you
+  import it from \`styled-components/native\` instead. Try this example with
+  [Snack by Expo](https://snack.expo.io/@danielmschmidt/styled-components).
 
-  \`\`\`jsx
-  import React from 'react'
-  import styled from 'styled-components/native';
+  ~~~jsx
+  import React from "react";
+  import styled from "styled-components/native";
 
   const StyledView = styled.View\`
     background-color: papayawhip;
@@ -24,33 +25,36 @@ const ReactNative = () => md`
         <StyledView>
           <StyledText>Hello World!</StyledText>
         </StyledView>
-      )
+      );
     }
   }
-  \`\`\`
+  ~~~
 
-  We also support more complex styles (like \`transform\`), which would normally be an array,
-  and shorthands (e.g. for \`margin\`) thanks to \`css-to-react-native\`!
+  We also support more complex styles (like \`transform\`), which would normally
+  be an array, and shorthands (e.g. for \`margin\`) thanks to
+  \`css-to-react-native\`!
 
   Imagine how you'd write the property in React Native, guess how you'd transfer
   it to CSS, and you're probably right:
 
-  \`\`\`jsx
+  ~~~jsx
   const RotatedBox = styled.View\`
     transform: rotate(90deg);
     text-shadow-offset: 10px 5px;
     font-variant: small-caps;
     margin: 5px 7px 2px;
   \`;
-  \`\`\`
+  ~~~
 
-  Some of the differences to the web-version are, that you cannot use
-  the \`keyframes\` and \`injectGlobal\` helpers since React Native doesn't
-  support keyframes or global styles. We will also warn you if you use media queries or nest your CSS.
+  Some of the differences to the web-version are, that you cannot use the
+  \`keyframes\` and \`injectGlobal\` helpers since React Native doesn't support
+  keyframes or global styles. We will also warn you if you use media queries or
+  nest your CSS.
 
-  > In v2 we support percentages. To make this possible we need to enforce units for all shorthands.
-  > If you're migrating to v2,
+  > In v2 we support percentages. To make this possible we need to enforce units
+  > for all shorthands. If you're migrating to v2,
   > [a codemod is available](https://github.com/styled-components/styled-components-native-code-mod).
+
 `
 
 export default ReactNative


### PR DESCRIPTION
This relates to #6. I don't know if it really solves this issue, but reading the discussion it seemed like a good tradeoff between keeping the design and adding a playground element.

Hope this helps, if you need any changes just ping me 👍 
(Embedding doesn't work due to https://github.com/rexxars/commonmark-react-renderer/issues/9 by the way)