### PR TITLE
Fix slug generation and sidebar order

### DIFF
--- a/pages/docs.json
+++ b/pages/docs.json
@@ -114,9 +114,9 @@
       "sections": [
         { "title": "Can I nest rules?" },
         { "title": "Can I refer to other components?" },
+        { "title": "When should I use styled()?" },
         { "title": "Can I use css frameworks?" },
-        { "title": "Why do my DOM nodes have two classes?" },
-        { "title": "When should I use styled()?" }
+        { "title": "Why do my DOM nodes have two classes?" }
       ]
     }
   ]

--- a/utils/elementToText.js
+++ b/utils/elementToText.js
@@ -7,7 +7,7 @@ const elementToTextRec = x => {
   if (Array.isArray(x)) {
     return x.map(elementToTextRec).join('')
   } else if (isValidElement(x)) {
-    return elementToTextRec(x.props.children)
+    return elementToTextRec(x.children || x.props.children)
   } else if (typeof x === 'string') {
     return x || ''
   }


### PR DESCRIPTION
The "[When should I use `styled()?`](https://www.styled-components.com/docs/faqs#when-should-i-use-styled)" link under FAQs was not in the right order compared to the other headings on the page. Its anchor was also broken. 

This fixes that link's order and anchor, along with any other slugs generated from titles that had `code` markdown.

The slugs were fine on dev but broken in the build. It was because Preact uses x.children compared to x.props.children in React.