### PR TITLE
Override inline styles

### DIFF
--- a/pages/docs.json
+++ b/pages/docs.json
@@ -116,6 +116,7 @@
         { "title": "Can I refer to other components?" },
         { "title": "When should I use styled()?" },
         { "title": "Can I use css frameworks?" },
+        { "title": "How can I override styles with higher specificity?" },
         { "title": "Why do my DOM nodes have two classes?" }
       ]
     }

--- a/pages/docs.json
+++ b/pages/docs.json
@@ -117,6 +117,7 @@
         { "title": "When should I use styled()?" },
         { "title": "Can I use css frameworks?" },
         { "title": "How can I override styles with higher specificity?" },
+        { "title": "How can I override inline styles?" },
         { "title": "Why do my DOM nodes have two classes?" }
       ]
     }

--- a/pages/docs/faqs.js
+++ b/pages/docs/faqs.js
@@ -6,6 +6,7 @@ import ReverseSelectors from '../../sections/faqs/reverse-selectors'
 import ExtendAndStyled from '../../sections/faqs/extend-and-styled-difference'
 import CSSFrameworks from '../../sections/faqs/support-for-css-frameworks'
 import OverrideStyles from '../../sections/faqs/override-styles-with-higher-specificity'
+import OverrideInlineStyles from '../../sections/faqs/override-inline-styles'
 import TwoDomClasses from '../../sections/faqs/dom-two-classes'
 
 const FAQs = () => (
@@ -15,6 +16,7 @@ const FAQs = () => (
     <ExtendAndStyled />
     <CSSFrameworks />
     <OverrideStyles />
+    <OverrideInlineStyles />
     <TwoDomClasses />
   </DocsLayout>
 )

--- a/pages/docs/faqs.js
+++ b/pages/docs/faqs.js
@@ -5,6 +5,7 @@ import Nesting from '../../sections/faqs/nesting'
 import ReverseSelectors from '../../sections/faqs/reverse-selectors'
 import ExtendAndStyled from '../../sections/faqs/extend-and-styled-difference'
 import CSSFrameworks from '../../sections/faqs/support-for-css-frameworks'
+import OverrideStyles from '../../sections/faqs/override-styles-with-higher-specificity'
 import TwoDomClasses from '../../sections/faqs/dom-two-classes'
 
 const FAQs = () => (
@@ -13,6 +14,7 @@ const FAQs = () => (
     <ReverseSelectors />
     <ExtendAndStyled />
     <CSSFrameworks />
+    <OverrideStyles />
     <TwoDomClasses />
   </DocsLayout>
 )

--- a/sections/faqs/override-inline-styles.js
+++ b/sections/faqs/override-inline-styles.js
@@ -1,0 +1,20 @@
+import md from 'components/md'
+
+const OverrideStyles = () => md`
+  ## How can I override inline styles?
+
+  Inline styles will always take precedence over external CSS, so you cannot override it by simply increasing specificity.
+  
+  There is a neat trick however, which is to use the style \`element-attr\` CSS Selector in conjunction with \`!important\`:
+
+  \`\`\`js
+  const MyStyledComponent = styled(InlineStyledComponent)\`
+    &[style] {
+      font-size: 12px !important;
+      color: blue !important;
+    }
+  \`;
+  \`\`\`
+`
+
+export default OverrideStyles

--- a/sections/faqs/override-styles-with-higher-specificity.js
+++ b/sections/faqs/override-styles-with-higher-specificity.js
@@ -3,9 +3,9 @@ import md from 'components/md'
 const OverrideStyles = () => md`
   ## How can I override styles with higher specificity?
 
-  The way to override styles with a high specificity is to simply increase the specificity of you own styles. This could be done using \`!important\`, but that's error prone and generally not a good idea.
+  The way to override styles with a high specificity is to simply increase the specificity of your own styles. This could be done using \`!important\`, but that's error prone and generally not a good idea.
 
-  We recommend the following technique;
+  We recommend the following technique:
 
   \`\`\`js
   const MyStyledComponent = styled(AlreadyStyledComponent)\`

--- a/sections/faqs/override-styles-with-higher-specificity.js
+++ b/sections/faqs/override-styles-with-higher-specificity.js
@@ -1,0 +1,31 @@
+import md from 'components/md'
+
+const OverrideStyles = () => md`
+  ## How can I override styles with higher specificity?
+
+  The way to override styles with a high specificity is to simply increase the specificity of you own styles. This could be done using \`!important\`, but that's error prone and generally not a good idea.
+
+  We recommend the following technique;
+
+  \`\`\`js
+  const MyStyledComponent = styled(AlreadyStyledComponent)\`
+    &&& {
+      color: palevioletred;
+      font-weight: bold;
+    }
+  \`;
+  \`\`\`
+  
+  Each \`&\` gets replaced with the generated class, so the injected CSS then looks like this:
+
+  \`\`\`css
+  .MyStyledComponent-asdf123.MyStyledComponent-asdf123.MyStyledComponent-asdf123 {
+    color: palevioletred;
+    font-weight: bold;
+  }
+  \`\`\`
+  
+  The repeated class bumps the specificity high enough to override the source order without being very tedious to write!
+`
+
+export default OverrideStyles


### PR DESCRIPTION
This builds on #199 and adds another section about overriding inline styles.

In the section I describe using the CSS style `element-attr` with `!important` since it seems to be the recommended way to override inline styles. In all honesty, I am having a hard time seeing how it differs from simply using `!important`. It might be more backwards compatible, but I cannot verify this.

So, we can either leave this as is, since it's sure to work, or we can simplify it to only use `!important`.

Sources
* https://css-tricks.com/override-inline-styles-with-css/
* https://stackoverflow.com/questions/16813220/how-can-i-override-inline-styles-with-external-css
* https://www.sitepoint.com/override-inline-css/