### PR TITLE
Normalize headings on releases page

### DIFF
--- a/components/Anchor.js
+++ b/components/Anchor.js
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components'
 import rem from '../utils/rem'
 
 import LinkIcon from 'react-octicons-svg/dist/LinkIcon'
-import { Header, SubHeader } from './Layout'
+import { Header, SubHeader, TertiaryHeader } from './Layout'
 import { mobile } from '../utils/media'
 
 const InvisibleAnchor = styled.div.attrs({
@@ -60,9 +60,21 @@ const AnchorHeader = styled(Header)`
 `
 
 const AnchorSubHeader = AnchorHeader.withComponent(SubHeader)
+const AnchorTertiaryHeader = AnchorHeader.withComponent(TertiaryHeader)
 
-const Link = ({ children, id, sub }) => {
-  const Child = sub ? AnchorSubHeader : AnchorHeader
+const Link = ({ children, level, id }) => {
+  let Child = AnchorHeader
+
+  switch(level) {
+    case 3:
+      Child = AnchorSubHeader
+      break
+    case 4:
+      Child = AnchorTertiaryHeader
+      break
+    default:
+      break
+  }
 
   return (
     <Child>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -55,3 +55,11 @@ export const SubHeader = styled.h3`
   font-weight: 500;
   font-family: ${headerFont};
 `
+
+export const TertiaryHeader = styled.h4`
+  display: block;
+  margin: ${rem(35)} 0 ${rem(22)} 0;
+  font-size: ${rem(18)};
+  font-weight: 600;
+  font-family: ${headerFont};
+`

--- a/components/md.js
+++ b/components/md.js
@@ -120,7 +120,7 @@ const md = (strings, ...values) => {
         const hash = titleToDash(title)
 
         return (
-          <Anchor id={hash} sub={level > 2}>
+          <Anchor id={hash} level={level}>
             {title}
             {labels.length > 0 && (
               <LabelGroup>

--- a/pages/releases.js
+++ b/pages/releases.js
@@ -7,6 +7,7 @@ import Anchor from '../components/Anchor'
 import Loading from '../components/Loading'
 import rem from '../utils/rem'
 import { getFormattedDate } from '../utils/dates'
+import normalizeMdHeadings from '../utils/normalizeMdHeadings'
 
 
 const ReleaseName = styled.span`
@@ -37,7 +38,7 @@ const Releases = ({ releases, sidebarPages }) => (
         <Anchor id={release.name}>
           <ReleaseName>{release.name} <Date>{getFormattedDate(release.created_at)}</Date></ReleaseName>
         </Anchor>
-        {md(release.body)}
+        {md(normalizeMdHeadings(release.body, 3))}
       </section>
     ) : <Loading />}
   </DocsLayout>

--- a/utils/normalizeMdHeadings.js
+++ b/utils/normalizeMdHeadings.js
@@ -1,0 +1,36 @@
+const firstHeadingMatch = /^(\s*)(#+)(\s.+)$/m
+const allHeadingsMatch = /^(\s*)(#+)(\s.+)$/mg
+
+const warningMessage = `
+normalizeMdHeadings() - Invalid starting level:
+
+Please use a value greater than 0.
+No changes have been made to your markdown.
+`
+
+const createHeading = (level = 1) =>
+  Array(Math.max(level, 1))
+  .fill('#')
+  .join('')
+
+const normalizeMdHeadings = (md, startingLevel = 1) => {
+  if (startingLevel < 1) {
+    console.warn(warningMessage)
+    return md
+  }
+
+  const firstHeading = md.match(firstHeadingMatch)
+
+  if (!firstHeading) {
+    return md
+  }
+
+  const modifier = startingLevel - firstHeading[2].length
+
+  return md.replace(allHeadingsMatch, (match, leadingSpace, level, content) => (
+    `${leadingSpace}${createHeading(level.length + modifier)}${content}`
+  ))
+
+}
+
+export default normalizeMdHeadings

--- a/utils/normalizeMdHeadings.js
+++ b/utils/normalizeMdHeadings.js
@@ -8,10 +8,22 @@ Please use a value greater than 0.
 No changes have been made to your markdown.
 `
 
-const createHeading = (level = 1) =>
-  Array(Math.max(level, 1))
-  .fill('#')
-  .join('')
+// dict of created headings to keep from calling Array().fill().join() more than needed.
+const headingsDict = {}
+
+const getHeading = (level = 1) => {
+  // prevent attempts at getting/making a heading < 1
+  level = Math.max(level, 1)
+
+  // if heading level hasn't been made before, make and add to dict
+  if (!headingsDict[level]) {
+    headingsDict[level] = Array(level)
+    .fill('#')
+    .join('')
+  }
+
+  return headingsDict[level]
+}
 
 const normalizeMdHeadings = (md, startingLevel = 1) => {
   if (startingLevel < 1) {
@@ -28,7 +40,7 @@ const normalizeMdHeadings = (md, startingLevel = 1) => {
   const modifier = startingLevel - firstHeading[2].length
 
   return md.replace(allHeadingsMatch, (match, leadingSpace, level, content) => (
-    `${leadingSpace}${createHeading(level.length + modifier)}${content}`
+    `${leadingSpace}${getHeading(level.length + modifier)}${content}`
   ))
 
 }


### PR DESCRIPTION
This is a first pass at fixing #202. Let me know if this is just a terrible way to go about it, or if there is something that needs changing. I've also added a `TertiaryHeading` component for h4's (anything greater than `## Heading 2` was just rendering h3).

for your viewing/checking for functionality/regressions: https://styled-components-docs-fghmothsit.now.sh/