### PR TITLE
Normalize headings on releases page

### DIFF
--- a/components/Anchor.js
+++ b/components/Anchor.js
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components'
 import rem from '../utils/rem'
 
 import LinkIcon from 'react-octicons-svg/dist/LinkIcon'
-import { Header, SubHeader } from './Layout'
+import { Header, SubHeader, TertiaryHeader } from './Layout'
 import { mobile } from '../utils/media'
 
 const InvisibleAnchor = styled.div.attrs({
@@ -60,9 +60,21 @@ const AnchorHeader = styled(Header)`
 `
 
 const AnchorSubHeader = AnchorHeader.withComponent(SubHeader)
+const AnchorTertiaryHeader = AnchorHeader.withComponent(TertiaryHeader)
 
-const Link = ({ children, id, sub }) => {
-  const Child = sub ? AnchorSubHeader : AnchorHeader
+const Link = ({ children, level, id }) => {
+  let Child = AnchorHeader
+
+  switch(level) {
+    case 3:
+      Child = AnchorSubHeader
+      break
+    case 4:
+      Child = AnchorTertiaryHeader
+      break
+    default:
+      break
+  }
 
   return (
     <Child>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -55,3 +55,11 @@ export const SubHeader = styled.h3`
   font-weight: 500;
   font-family: ${headerFont};
 `
+
+export const TertiaryHeader = styled.h4`
+  display: block;
+  margin: ${rem(35)} 0 ${rem(22)} 0;
+  font-size: ${rem(18)};
+  font-weight: 600;
+  font-family: ${headerFont};
+`

--- a/components/md.js
+++ b/components/md.js
@@ -56,12 +56,20 @@ const md = (strings, ...values) => {
     stripIndent(strings) :
     stripIndent(strings.join(PLACEHOLDER))
 
+  const idPrefix = typeof strings === 'string' && typeof values[0] === 'string' ?
+    values[0] + '_'  : ''
+
+  const startingLevel = typeof strings === 'string' ?
+    values[1] : null
+
   const parser = new Parser()
   const ast = parser.parse(input)
 
   if (!isValid(ast)) {
     throw new Error('Cannot interpolate React elements non-block positions')
   }
+
+  let topLevelHeading
 
   const renderer = new Renderer({
     renderers: {
@@ -101,6 +109,11 @@ const md = (strings, ...values) => {
       },
 
       Heading({ level, children }) {
+        if (startingLevel) {
+          topLevelHeading = topLevelHeading || Math.max(level, 1)
+          level+= startingLevel - topLevelHeading
+        }
+
         if (level === 1) {
           return <Title>{children}</Title>
         }
@@ -117,7 +130,7 @@ const md = (strings, ...values) => {
           return child
         })
 
-        const hash = titleToDash(title)
+        const hash = `${idPrefix}${titleToDash(title)}`
 
         return (
           <Anchor id={hash} sub={level > 2}>

--- a/components/md.js
+++ b/components/md.js
@@ -133,7 +133,7 @@ const md = (strings, ...values) => {
         const hash = `${idPrefix}${titleToDash(title)}`
 
         return (
-          <Anchor id={hash} sub={level > 2}>
+          <Anchor id={hash} level={level}>
             {title}
             {labels.length > 0 && (
               <LabelGroup>

--- a/pages/releases.js
+++ b/pages/releases.js
@@ -37,7 +37,7 @@ const Releases = ({ releases, sidebarPages }) => (
         <Anchor id={release.name}>
           <ReleaseName>{release.name} <Date>{getFormattedDate(release.created_at)}</Date></ReleaseName>
         </Anchor>
-        {md(release.body)}
+        {md(release.body, release.name, 3)}
       </section>
     ) : <Loading />}
   </DocsLayout>


### PR DESCRIPTION
A second pass at fixing #202 (per @philpl's suggestions in #213). This includes the `TertiaryHeading` component for `h4`'s (anything greater than `## Heading 2` was just rendering h3) from the closed #213.

Also adds ability to specify an id prefix when `md()` is used as a normal function. This is being used to keep from having a bunch of duplicate anchors/ids on the releases page. Closes #214.

for your viewing/checking for functionality/regressions: https://styled-components-docs-ntjcjteypa.now.sh/