### PR TITLE
Fix broken link: when to use styled

### DIFF
--- a/sections/basics/extending-styles.js
+++ b/sections/basics/extending-styles.js
@@ -46,7 +46,7 @@ const ExtendingStyles = () => md`
   > You should only use \`Comp.extend\` if you know that \`Comp\` is a styled component.
   > If you're importing from another file or a third party library, prefer to use
   > \`styled(Comp)\` as it accomplishes the same thing but works with *any* React
-  > component. Read more about [what the difference between \`Comp.extend\` and \`styled(Comp)\` is.](/docs/faqs#when-should-i-use-)
+  > component. Read more about [what the difference between \`Comp.extend\` and \`styled(Comp)\` is.](/docs/faqs#when-should-i-use-styled)
 
   In really rare cases you might want to change which tag or component a styled component renders.
   For this case, we have an escape hatch. You can use the <Code>withComponent</Code> to extend


### PR DESCRIPTION
This change fixes a broken link to the FAQ page