### PR TITLE
Clarify that SSR methods only work after wrapped components are rendered

### DIFF
--- a/sections/advanced/server-side-rendering.js
+++ b/sections/advanced/server-side-rendering.js
@@ -46,6 +46,8 @@ const ServerSideRendering = () => md`
   Alternatively the \`ServerStyleSheet\` instance also has a \`getStyleElement()\` method
   that returns an array of React elements.
 
+  Note that \`sheet.getStyleTags()\` and \`sheet.getStyleElement()\` can only be called after your element is rendered. As a result, components from \`sheet.getStyleElement()\` cannot be combined with \`<YourApp />\` into a larger component.
+
   ### Next.js
 
   Basically you need to add a custom \`pages/_document.js\` (if you don't have one). Then 

--- a/sections/advanced/server-side-rendering.js
+++ b/sections/advanced/server-side-rendering.js
@@ -46,7 +46,7 @@ const ServerSideRendering = () => md`
   Alternatively the \`ServerStyleSheet\` instance also has a \`getStyleElement()\` method
   that returns an array of React elements.
 
-  Note that \`sheet.getStyleTags()\` and \`sheet.getStyleElement()\` can only be called after your element is rendered. As a result, components from \`sheet.getStyleElement()\` cannot be combined with \`<YourApp />\` into a larger component.
+  > \`sheet.getStyleTags()\` and \`sheet.getStyleElement()\` can only be called after your element is rendered. As a result, components from \`sheet.getStyleElement()\` cannot be combined with \`<YourApp />\` into a larger component.
 
   ### Next.js
 


### PR DESCRIPTION
This clarifies that it's not possible to use tags from `sheet.getStyleTags()`  in the same tree as the component that `sheet` is wrapping. For example, one could mistakenly try to do something like this to include their app and the generated `<style>` tags as part of a larger component, but in fact this does not work:

```js
const wrapperConstructor = () => {
  const stylesheet = new ServerStyleSheet();
  const wrappedComponent = stylesheet.collectStyles(<YourApp />);

  return (
    <div>
      {stylesheet.getStyleElement()}
      {wrappedComponent}
    </div>
  );
};
```