### PR TITLE
Fix typo in tooling section

### DIFF
--- a/sections/tooling/styled-theming.js
+++ b/sections/tooling/styled-theming.js
@@ -247,7 +247,7 @@ const StyledTheming = () => md`
   import styled from 'styled-components';
   import theme from 'styled-theming';
 
-  const backgroundColor = theme.variants('variant', 'mode', {
+  const backgroundColor = theme.variants('mode', 'variant', {
     default: { light: 'gray', dark: 'darkgray' },
     primary: { light: 'blue', dark: 'darkblue' },
     success: { light: 'green', dark: 'darkgreen' },


### PR DESCRIPTION
It seems like there is a typo in the style-components tooling section;

The first parameter for `theme.variants` is the 'theme'-mode and not the prop name used chose the variant. 

https://github.com/styled-components/styled-theming#themevariantsname-prop-themes