### PR TITLE
Fix link reference

### DIFF
--- a/sections/api/primary/styled-component.js
+++ b/sections/api/primary/styled-component.js
@@ -11,7 +11,7 @@ const StyledComponent = () => md`
   call \`styled.tagname\` or \`styled(Component)\` with styles.
 
   This component can take any prop. It passes it on to the HTML node if it's a valid attribute,
-  otherwise it only passes it into interpolated functions. (see [Tagged Template Literal](/advanced/#tagged-template-literals))
+  otherwise it only passes it into interpolated functions. (see [Tagged Template Literal](/docs/advanced/#tagged-template-literals))
 
   You can pass an arbitrary classname to a styled component without problem and it will be applied
   next to the styles defined by the styled call.


### PR DESCRIPTION
I've been reading the documentation and I found a broken link reference.

![screen shot 2018-02-21 at 2 25 17 pm](https://user-images.githubusercontent.com/12464600/36482286-156fc132-1713-11e8-838a-738bbb7a835e.png)

When you click on `see Tagged Template Literal`, we're redirect to an unknown route and consequently get 404. ([Direct Link to the oficial doc](https://www.styled-components.com/docs/api#styledcomponent))

Just add "doc" prefix and now it's working as should be.
