### PR TITLE
Advanced media template has extra `/16`

### DIFF
--- a/sections/advanced/media-templates.js
+++ b/sections/advanced/media-templates.js
@@ -39,7 +39,7 @@ const MediaTemplates = () => md`
   // Iterate through the sizes and create a media template
   const media = Object.keys(sizes).reduce((acc, label) => {
     acc[label] = (...args) => css\`
-      @media (max-width: \${sizes[label] / 16}em) {
+      @media (max-width: \${sizes[label]}em) {
         \${css(...args)}
       }
     \`


### PR DESCRIPTION
I try to use advanced's media template but not work well.
I found the strange calculate `${sizes[label] / 16}`.

What is `/16` ? I guess it's maybe typo.