### PR TITLE
Fix broken tagged-template-literals URL

### DIFF
--- a/sections/tooling/babel-plugin.js
+++ b/sections/tooling/babel-plugin.js
@@ -17,7 +17,7 @@ const BabelPlugin = () => md`
   Then add it to your babel configuration like so:
 
   > ⚠️ The plugin call order in your \`\`\`.babelrc\`\`\` file matters. If you're using the env property in your babel configuration, then putting this plugin into the plugins array won't suffice. Instead it needs to be put into each env's plugins array to maintain it being executed first. See [this](https://github.com/styled-components/babel-plugin-styled-components/issues/78) for more information.
-  
+
   \`\`\`js
   {
     "plugins": ["babel-plugin-styled-components"]
@@ -131,7 +131,7 @@ const BabelPlugin = () => md`
   because \`styled-components\` template literals don't need to
   be 100% spec compliant.
 
-  Read more about [Tagged Template Literals](#tagged-template-literals) in
+  Read more about [Tagged Template Literals](/docs/advanced#tagged-template-literals) in
   our dedicated section explaining them.
 
   You can use the \`transpileTemplateLiterals\` option to turn this feature off.


### PR DESCRIPTION
Fixes the broken `tagged-template-literals` url in the [_Template String Transpilation_](https://www.styled-components.com/docs/tooling#template-string-transpilation) section.