### PR TITLE
Use consistent CLI examples in Tooling section

### DIFF
--- a/sections/tooling/test-utilities.js
+++ b/sections/tooling/test-utilities.js
@@ -11,7 +11,7 @@ const TestUtilities = () => md`
   ### Installation
 
   \`\`\`
-  yarn add --dev jest-styled-components
+  npm install --dev jest-styled-components
   \`\`\`
 
   ### Snapshot Testing


### PR DESCRIPTION
Hey,

while browsing the *Tooling* section all CLI examples start off with `npm install`, except for the *Test Utilities* section where it's still a `yarn add` reference. Since many people will just copy the commands, this is inconsistent, and add unwanted files (`yarn-lock`). :)