### PR TITLE
Update html-attribute-warnings.js

### DIFF
--- a/sections/faqs/html-attribute-warnings.js
+++ b/sections/faqs/html-attribute-warnings.js
@@ -26,7 +26,7 @@ const HTMLAttributeWarnings = () => md`
   }
 
   const StyledComp = styled(Link)\`
-    color: \${props.red ? "red" : "blue"};
+    color: \${props => props.red ? "red" : "blue"};
   \`
 
   <StyledComp text="Click" href="https://www.styled-components.com/" red />


### PR DESCRIPTION
I think it should be `props => props.red ? "red" : "blue"`