### PR TITLE
Adds button onClick to styled-component example

### DIFF
--- a/sections/basics/coming-from-css.md
+++ b/sections/basics/coming-from-css.md
@@ -42,8 +42,8 @@ class Counter extends React.Component {
     return (
       <StyledCounter>
         <Paragraph>{this.state.count}</Paragraph>
-        <Button>+</Button>
-        <Button>-</Button>
+        <Button onClick={this.increment}>+</Button>
+        <Button onClick={this.decrement}>-</Button>
       </StyledCounter>
     )
   }


### PR DESCRIPTION
In a comparison between CSSModules and Styled Components, the Styled Components example was missing the onClick methods to actually modify state.

Relates to issue #311 