### PR TITLE
Fix samples auto-formatted by prettier

### DIFF
--- a/sections/tooling/stylelint.md
+++ b/sections/tooling/stylelint.md
@@ -216,9 +216,9 @@ The important thing is that you put the closing backtick on the base level of in
 
 ```js
 if (condition) {
-const Button = styled.button`
-  color: red;
-`
+  const Button = styled.button`
+    color: red;
+  `
 }
 ```
 
@@ -226,16 +226,16 @@ const Button = styled.button`
 
 ```js
 if (condition) {
-const Button = styled.button`
-  color: red;
+  const Button = styled.button`
+    color: red;
 `
 }
 ```
 
 ```js
 if (condition) {
-const Button = styled.button`
-  color: red;`
+  const Button = styled.button`
+    color: red;`
 }
 ```
 

--- a/sections/tooling/stylelint.md
+++ b/sections/tooling/stylelint.md
@@ -216,9 +216,9 @@ The important thing is that you put the closing backtick on the base level of in
 
 ```js
 if (condition) {
-  const Button = styled.button`
-    color: red;
-  `
+const Button = styled.button`
+  color: red;
+`
 }
 ```
 
@@ -226,17 +226,16 @@ if (condition) {
 
 ```js
 if (condition) {
-  const Button = styled.button`
-    color: red;
-  `
+const Button = styled.button`
+  color: red;
+`
 }
 ```
 
 ```js
 if (condition) {
-  const Button = styled.button`
-    color: red;
-  `
+const Button = styled.button`
+  color: red;`
 }
 ```
 


### PR DESCRIPTION
Fixes #330.

Now it should be the same with the original meaning in https://github.com/styled-components/styled-components-website/commit/d18b0ca6a5722e86459d91874103026f7c11851a.