### PR TITLE
Add flex:none to an SVG in examples

### DIFF
--- a/sections/advanced/components-as-selectors.md
+++ b/sections/advanced/components-as-selectors.md
@@ -21,6 +21,7 @@ const Link = styled.a`
 `;
 
 const Icon = styled.svg`
+  flex: none;
   transition: fill 0.25s;
   width: 48px;
   height: 48px;


### PR DESCRIPTION
Add `flex: none` to the svg icon to prevent it from shrinking to oblivion in the [referring to other components example](https://www.styled-components.com/docs/advanced#referring-to-other-components).

**Before**:
<img width="984" alt="screenshot 2018-10-01 at 16 33 56" src="https://user-images.githubusercontent.com/1710629/46295261-e6efaa00-c597-11e8-89cd-fa51235e8d53.png">


**After**:
<img width="984" alt="screenshot 2018-10-01 at 16 34 13" src="https://user-images.githubusercontent.com/1710629/46295257-e525e680-c597-11e8-9d73-41939092a4ef.png">