### PR TITLE
Add note that keyframes don't work on react-native

### DIFF
--- a/sections/basics/animations.md
+++ b/sections/basics/animations.md
@@ -31,3 +31,5 @@ render(
   <Rotate>&lt; 💅 &gt;</Rotate>
 );
 ```
+
+> Keyframes are not supported by `react-native`. Instead, use the `React.Animated` API, as demonstrated [here](https://stackoverflow.com/questions/50891046/rotate-an-svg-in-react-native/50891225#50891225)


### PR DESCRIPTION
Per https://github.com/styled-components/styled-components/issues/2024, keyframes don't work on `react-native`, but this is currently not noted anywhere in the documentation.