### PR TITLE
update v4 migration guide

### DIFF
--- a/sections/faqs/migration-v4.md
+++ b/sections/faqs/migration-v4.md
@@ -166,19 +166,7 @@ const Component = styled.div`
 7. If you're using TypeScript, the typings are now located in DefinitelyTyped:
 
 ```
-npm install @types/styled-components
+npm install @types/styled-components@^4
 ```
-
-They have not been updated yet for v4, so help on that front is extremely welcome! We won't release a formal v4 version until they're in place.
 
 That's it! Aside from migrating, we also highly recommend reading up on the new [`"as" prop`](/docs/api#as-polymorphic-prop) which is intended to replace the [`withComponent API`](/docs/api#withcomponent) in the future.
-
-8. If you are using react-router v4:
-
-```
-npm install react-router@next react-router-dom@next
-```
-
-They have not formally released a version of the library yet using the new React v16 context implementation, so certain things will not work inside the styled-components PureComponent wrapper. The "next" tag has a working version though.
-
-This goes for any other library that is not using `React.createContext` or the `create-react-context` polyfill as well. In general, all libraries should migrate as soon as possible.


### PR DESCRIPTION
1. v4 typings are now out
2. react-router* upgrade no longer needed