### PR TITLE
Update (fix) docs Refs example

### DIFF
--- a/sections/advanced/refs.md
+++ b/sections/advanced/refs.md
@@ -18,18 +18,17 @@ const Input = styled.input`
 class Form extends React.Component {
   constructor(props) {
     super(props);
-
-    this.setInputRef = (element) => {
-      this.input = element;
-    }
+    this.inputRef = React.createRef();
   }
 
   render() {
     return (
       <Input
-        ref={this.setInputRef}
+        ref={this.inputRef}
         placeholder="Hover to focus!"
-        onMouseEnter={() => this.input.base.focus()}
+        onMouseEnter={() => {
+          this.inputRef.current.focus()
+        }}
       />
     );
   }


### PR DESCRIPTION
Hi! 👋

I'm not sure if there is a fix for this issue already in another branch or something, but I noticed that the example located at https://www.styled-components.com/docs/advanced#refs doesn't currently work and throws this error:

<img width="487" alt="screen shot 2018-10-13 at 12 46 39 pm" src="https://user-images.githubusercontent.com/2100222/46908176-bfc89f00-ceec-11e8-90ad-b26ef30e1ddb.png">

This PR attempts to fix that example.

This issue could have been fixed by removing `.base`, which I'm not sure why it was used for.

```diff
  <Input
    ref={this.setInputRef}
    placeholder="Hover to focus!"
-   onMouseEnter={() => this.input.base.focus()}
+   onMouseEnter={() => this.input.focus()}
  />
```

However, the example uses a callback-style Ref. I figured it could be updated to use the new `createRef` API as well, unless there is reason not to.

**Before**

https://www.styled-components.com/docs/advanced#refs

**After**

https://styled-components-jubuiqkgwn.now.sh/docs/advanced#refs