### PR TITLE
Add css helper in animations example

### DIFF
--- a/sections/basics/animations.md
+++ b/sections/basics/animations.md
@@ -1,14 +1,10 @@
 ## Animations
 
-CSS animations with `@keyframes` aren't scoped to a single component but you still don't want them to be global. This is why we export a `keyframes` and a `css` helper which will generate a unique name for your keyframes. You can then use that unique name throughout your app.
-In general, always use the `css` helper when composing styling partials to be interpolated into a styled component,
-because then it's possible to lazily inject keyframes and work with code splitting.
-
-This way, you get all the benefits of using JavaScript, are avoiding name clashes and get your keyframes like always:
+CSS animations with `@keyframes` aren't scoped to a single component but you still don't want them to be global to avoid name collisions. This is why we export a `keyframes` helper which will generate a unique instance that you can use throughout your app:
 
 ```react
-// keyframes returns a unique keyframe object
-const rotate360 = keyframes`
+// Create the keyframes
+const rotate = keyframes`
   from {
     transform: rotate(0deg);
   }
@@ -18,15 +14,10 @@ const rotate360 = keyframes`
   }
 `;
 
-// use the keyframe in a css helper
-const rotateAnimation = css`
-  ${rotate360} 2s linear infinite
-`
-
 // Here we create a component that will rotate everything we pass in over two seconds
 const Rotate = styled.div`
   display: inline-block;
-  animation: ${rotateAnimation};
+  animation: ${rotate} 2s linear infinite;
   padding: 2rem 1rem;
   font-size: 1.2rem;
 `;
@@ -37,3 +28,21 @@ render(
 ```
 
 > Keyframes are not supported by `react-native`. Instead, use the [`ReactNative.Animated` API](https://stackoverflow.com/questions/50891046/rotate-an-svg-in-react-native/50891225#50891225).
+
+Keyframes are lazily injected when they're used, which is how they can be code-splitted, so you have to use [the `css` helper](/docs/api#css) for shared style fragments:
+
+```javascript
+const rotate = keyframes``
+
+// ❌ This will throw an error!
+const styles = `
+  animation: ${rotate} 2s linear infinite;
+`;
+
+// ✅ This will work as intended
+const styles = css`
+  animation: ${rotate} 2s linear infinite;
+`
+```
+
+> This used to work in v3 and below where we didn't code-split keyframes. If you're upgrading from v3, make sure that all your shared style fragments are using the `css` helper!

--- a/sections/basics/animations.md
+++ b/sections/basics/animations.md
@@ -1,11 +1,13 @@
 ## Animations
 
-CSS animations with `@keyframes` aren't scoped to a single component but you still don't want them to be global. This is why we export a `keyframes` helper which will generate a unique name for your keyframes. You can then use that unique name throughout your app.
+CSS animations with `@keyframes` aren't scoped to a single component but you still don't want them to be global. This is why we export a `keyframes` and a `css` helper which will generate a unique name for your keyframes. You can then use that unique name throughout your app.
+In general, always use the `css` helper when composing styling partials to be interpolated into a styled component,
+because then it's possible to lazily inject keyframes and work with code splitting.
 
 This way, you get all the benefits of using JavaScript, are avoiding name clashes and get your keyframes like always:
 
 ```react
-// keyframes returns a unique name based on a hash of the contents of the keyframes
+// keyframes returns a unique keyframe object
 const rotate360 = keyframes`
   from {
     transform: rotate(0deg);
@@ -16,10 +18,15 @@ const rotate360 = keyframes`
   }
 `;
 
+// use the keyframe in a css helper
+const rotateAnimation = css`
+  ${rotate360} 2s linear infinite
+`
+
 // Here we create a component that will rotate everything we pass in over two seconds
 const Rotate = styled.div`
   display: inline-block;
-  animation: ${rotate360} 2s linear infinite;
+  animation: ${rotateAnimation};
   padding: 2rem 1rem;
   font-size: 1.2rem;
 `;


### PR DESCRIPTION
Because of the discussion with Max and me at spectrum (https://spectrum.chat/thread/29aa3ecf-0927-40d6-963f-c475a389298e) I created that PR.

I added a code snippet which consists the animation value in a css helper.

I am not sure if my description for the need of the css helper is correct and moreover I am not sure if keyframes returns a unique keyframe object or something else.