### PR TITLE
Improve Babel Macro documentation.

### DIFF
--- a/sections/tooling/babel-macro.md
+++ b/sections/tooling/babel-macro.md
@@ -5,10 +5,16 @@
 If your scaffold is set up with [`babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros), then simply use the new `styled-components/macro` import instead of `styled-components`:
 
 ```js
-import styled from 'styled-components/macro'
+import styled, { createGlobalStyle } from 'styled-components/macro'
 
 const Thing = styled.div`
   color: red;
+`
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    color: 'white';
+  }
 `
 ```
 
@@ -20,13 +26,13 @@ The macro incorporates all the functionality of [our babel plugin](/docs/tooling
 can be located in any of the following files up the directories from the
 importing file:
 
-* `.babel-plugin-macrosrc`
-* `.babel-plugin-macrosrc.json`
-* `.babel-plugin-macrosrc.yaml`
-* `.babel-plugin-macrosrc.yml`
-* `.babel-plugin-macrosrc.js`
-* `babel-plugin-macros.config.js`
-* `babelMacros` in `package.json`
+- `.babel-plugin-macrosrc`
+- `.babel-plugin-macrosrc.json`
+- `.babel-plugin-macrosrc.yaml`
+- `.babel-plugin-macrosrc.yml`
+- `.babel-plugin-macrosrc.js`
+- `babel-plugin-macros.config.js`
+- `babelMacros` in `package.json`
 
 You can then specify the same options as [our babel plugin](/docs/tooling#babel-plugin) in `styledComponents` entry:
 
@@ -42,3 +48,22 @@ module.exports = {
 ```
 
 For more information, see [EXPERIMENTAL config for babel-plugin-macros ](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/author.md#config-experimental).
+
+### Enforce macro imports
+
+You may want to ensure that objects are consistently imported from the macro across your project. This can be achieved by using a [`no-restricted-imports`](https://eslint.org/docs/rules/no-restricted-imports) rule from ESLint:
+
+```json
+"no-restricted-imports": [
+  "error",
+  {
+    "paths": [{
+      "name": "styled-components",
+      "message": "Please import from styled-components/macro."
+    }],
+    "patterns": [
+      "!styled-components/macro"
+    ]
+  }
+]
+```


### PR DESCRIPTION
- Make explicit that you should also import named imports from the macro.
- Add a section to enforce imports from the macro.