### PR TITLE
Add previous API's note to extending styles section

### DIFF
--- a/sections/api/primary/styled-component.md
+++ b/sections/api/primary/styled-component.md
@@ -89,8 +89,6 @@ applied to it, but all the same rules of the one it's called on.
 
 Returns a new `StyledComponent` with the new tag / component being applied when it's used.
 
-You can see it in action in the [Extending Styles](/docs/basics#extending-styles) section.
-
 > As of styled-components v4 the `withComponent` API is now a candidate for deprecation. In all likelihood, you probably want to use the new [`"as"` prop](#as-polymorphic-prop) to simply switch what element/component being rendered since the `withComponent` API is destructive toward styles if the lowest-wrapped component is a `StyledComponent`.
 
 #### `"as"` polymorphic prop | v4

--- a/sections/basics/extending-styles.md
+++ b/sections/basics/extending-styles.md
@@ -82,3 +82,5 @@ render(
   </div>
 );
 ```
+
+> If you are still on an older version than v4, you can use the [`.withComponent`](/docs/api#withcomponent) or [`.extend`](/docs/api#deprecated-extend) API's to achieve the same result as with the [`"as" prop`](/docs/api#as-polymorphic-prop), but note that this is discouraged as with v4 [`.extend` was removed](/releases#breaking-changes) and `.withComponent` was marked as a candidate for future deprecation.


### PR DESCRIPTION
Closes https://github.com/styled-components/styled-components-website/issues/371

* Add a note to the **Extending Styles** section referencing and discouring the usage of the previous API's : `.withComponent` and `.extend`.
* Remove the reference to **Extending Styles** from the `.withComponent` section.