### PR TITLE
Code editor scroll bar bug on chrome 70

### DIFF
--- a/components/LiveEdit.js
+++ b/components/LiveEdit.js
@@ -50,6 +50,7 @@ export const editorMixin = `
   overflow-x: hidden;
   cursor: text;
   white-space: pre-wrap;
+  position: relative;
 `;
 
 const StyledEditor = styled(LiveEditor)`

--- a/test/components/__snapshots__/LiveEdit.spec.js.snap
+++ b/test/components/__snapshots__/LiveEdit.spec.js.snap
@@ -36,6 +36,7 @@ exports[`LiveEdit renders correctly 1`] = `
   overflow-x: hidden;
   cursor: text;
   white-space: pre-wrap;
+  position: relative;
   -webkit-flex-basis: 50%;
   -ms-flex-preferred-size: 50%;
   flex-basis: 50%;
@@ -248,6 +249,7 @@ exports[`LiveEdit renders correctly 1`] = `
   overflow-x: hidden;
   cursor: text;
   white-space: pre-wrap;
+  position: relative;
 ",
                             ";
   ",


### PR DESCRIPTION
Closes https://github.com/styled-components/styled-components-website/issues/395

![kapture 2018-12-03 at 18 59 26](https://user-images.githubusercontent.com/3718438/49392085-b231d780-f72d-11e8-9a6d-a7f40c70ea1d.gif)

Not really sure what's the reason that caused the visual bug in the code editor on chrome 70, but adding a relative position to the `editorMixin` in `LiveEdit.js` fixes the scrollbar issue without changing the behaviour of anything else.