### PR TITLE
Add Hooks example to Themeing > Getting theme without styled components

### DIFF
--- a/sections/advanced/theming.md
+++ b/sections/advanced/theming.md
@@ -109,6 +109,19 @@ class MyComponent extends React.Component {
 export default withTheme(MyComponent);
 ```
 
+You can also use `useContext` to access the current theme outside of styled components when working with React Hooks.
+
+```jsx
+import { ThemeContext } from 'styled-components';
+
+const MyComponent = () => {
+  const themeContext = useContext(ThemeContext);
+
+  console.log('Current theme: ', this.props.theme);
+  // ...
+};
+```
+
 ### The `theme` prop
 
 A theme can also be passed down to a component using the `theme` prop.

--- a/sections/advanced/theming.md
+++ b/sections/advanced/theming.md
@@ -93,7 +93,7 @@ render(
 
 ### Getting the theme without styled components
 
-#### Using `withTheme` for Higher Order Components
+#### via `withTheme` higher-order component
 
 If you ever need to use the current theme outside styled components (e.g. inside big components), you can use
 the `withTheme` higher order component.
@@ -111,7 +111,7 @@ class MyComponent extends React.Component {
 export default withTheme(MyComponent);
 ```
 
-#### Using React Hooks `useContext` | v4
+#### via `useContext` React hook | v4
 
 You can also use `useContext` to access the current theme outside of styled components when working with React Hooks. | v4
 

--- a/sections/advanced/theming.md
+++ b/sections/advanced/theming.md
@@ -93,33 +93,38 @@ render(
 
 ### Getting the theme without styled components
 
+#### Using `withTheme` for Higher Order Components
+
 If you ever need to use the current theme outside styled components (e.g. inside big components), you can use
 the `withTheme` higher order component.
 
 ```jsx
-import { withTheme } from 'styled-components';
+import { withTheme } from 'styled-components'
 
 class MyComponent extends React.Component {
   render() {
-    console.log('Current theme: ', this.props.theme);
+    console.log('Current theme: ', this.props.theme)
     // ...
   }
 }
 
-export default withTheme(MyComponent);
+export default withTheme(MyComponent)
 ```
 
-You can also use `useContext` to access the current theme outside of styled components when working with React Hooks.
+#### Using React Hooks `useContext` | v4
+
+You can also use `useContext` to access the current theme outside of styled components when working with React Hooks. | v4
 
 ```jsx
-import { ThemeContext } from 'styled-components';
+import { useContext } from 'react'
+import { ThemeContext } from 'styled-components'
 
 const MyComponent = () => {
-  const themeContext = useContext(ThemeContext);
+  const themeContext = useContext(ThemeContext)
 
-  console.log('Current theme: ', this.props.theme);
+  console.log('Current theme: ', this.props.theme)
   // ...
-};
+}
 ```
 
 ### The `theme` prop

--- a/sections/advanced/theming.md
+++ b/sections/advanced/theming.md
@@ -99,16 +99,16 @@ If you ever need to use the current theme outside styled components (e.g. inside
 the `withTheme` higher order component.
 
 ```jsx
-import { withTheme } from 'styled-components'
+import { withTheme } from 'styled-components';
 
 class MyComponent extends React.Component {
   render() {
-    console.log('Current theme: ', this.props.theme)
+    console.log('Current theme: ', this.props.theme);
     // ...
   }
 }
 
-export default withTheme(MyComponent)
+export default withTheme(MyComponent);
 ```
 
 #### Using React Hooks `useContext` | v4
@@ -116,13 +116,13 @@ export default withTheme(MyComponent)
 You can also use `useContext` to access the current theme outside of styled components when working with React Hooks. | v4
 
 ```jsx
-import { useContext } from 'react'
-import { ThemeContext } from 'styled-components'
+import { useContext } from 'react';
+import { ThemeContext } from 'styled-components';
 
 const MyComponent = () => {
-  const themeContext = useContext(ThemeContext)
+  const themeContext = useContext(ThemeContext);
 
-  console.log('Current theme: ', this.props.theme)
+  console.log('Current theme: ', this.props.theme);
   // ...
 }
 ```

--- a/sections/advanced/theming.md
+++ b/sections/advanced/theming.md
@@ -122,7 +122,7 @@ import { ThemeContext } from 'styled-components';
 const MyComponent = () => {
   const themeContext = useContext(ThemeContext);
 
-  console.log('Current theme: ', this.props.theme);
+  console.log('Current theme: ', themeContext);
   // ...
 }
 ```

--- a/sections/advanced/theming.md
+++ b/sections/advanced/theming.md
@@ -113,7 +113,7 @@ export default withTheme(MyComponent);
 
 #### via `useContext` React hook | v4
 
-You can also use `useContext` to access the current theme outside of styled components when working with React Hooks. | v4
+You can also use `useContext` to access the current theme outside of styled components when working with React Hooks.
 
 ```jsx
 import { useContext } from 'react';


### PR DESCRIPTION
Adds a sentence and small code example of getting theme outside of styled components when using React Hooks. Right now there is an example using ```withTheme``` for HOCs, but I think this would be a good addition for anyone using Hooks in their codebase to save a little time searching for the way to achieve this in Hooks.

**Before**

![before_docs](https://user-images.githubusercontent.com/22606045/57037151-062ce380-6c1c-11e9-93cd-c0b575637b72.png)

**After**

![after_2](https://user-images.githubusercontent.com/22606045/57050669-6edb8680-6c43-11e9-8fa6-f1dff84c706d.png)

