### PR TITLE
Fix invalid Typescript example of custom prop typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ git clone https://github.com/styled-components/styled-components-website
 # Enter the repo
 cd styled-components-website
 # Install the dependencies
-npm install
+yarn install
 # Start local development
-npm run dev
+yarn dev
 ```
 
-> Note: This requires Node.js and npm to be set up locally, see [nodejs.org](https://nodejs.org) for more information.
+> Note: This requires Node.js and yarn to be set up locally, see [nodejs.org](https://nodejs.org) for more information.
 
 ### Updating the visual diffs
 

--- a/sections/api/typescript.md
+++ b/sections/api/typescript.md
@@ -156,12 +156,11 @@ you follow this convention:
 import styled from 'styled-components'
 import Header, { Props as HeaderProps } from './Header'
 
-const Title =
-  (styled < { isActive: boolean }) &
-  (HeaderProps >
-    (({ isActive, ...rest }) => <Header {...rest} />)`
+const Title = styled<
+  React.ComponentType<HeaderProps & { isActive: boolean }>>
+  (({ isActive, ...rest })) => <Header {...rest} />)`
   color: ${props => (props.isActive ? props.theme.primaryColor : props.theme.secondaryColor)}
-`)
+`
 ```
 
 This is the most complex example where we have specific properties for the styling of the component and pass


### PR DESCRIPTION
Hey everyone, as discussed [here](https://github.com/styled-components/styled-components-website/pull/437#issuecomment-527429146), I found an invalid typescript example and try to fix it in this PR. The current example contains syntax errors/invalid typescript. 

I further updated the contribution section of the README by replacing `npm` commands with `yarn`. There is no lock file for `npm` (package-lock.json), thus using `npm` for installing dependencies will cause a lot of unwanted side effects. 

Thanks for looking into this PR.