### PR TITLE
Fix NavButton CSS

### DIFF
--- a/components/Nav/NavButton.js
+++ b/components/Nav/NavButton.js
@@ -14,7 +14,7 @@ const NavButton = styled.button`
   text-align: center;
   vertical-align: middle;
 
-  & + ${NavButton} {
+  & + & {
     padding-left: 0;
   }
 `;

--- a/test/components/NavBar/__snapshots__/MobileNavbar.spec.js.snap
+++ b/test/components/NavBar/__snapshots__/MobileNavbar.spec.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MobileNavbar renders correctly 1`] = `
-.c2 svg {
+.c3 svg {
   display: inline-block;
 }
 
-.c2 svg path {
+.c3 svg path {
   fill: currentColor;
 }
 
-.c12 {
+.c13 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -21,7 +21,7 @@ exports[`MobileNavbar renders correctly 1`] = `
   opacity: 0.35;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -36,7 +36,7 @@ exports[`MobileNavbar renders correctly 1`] = `
   margin-right: 1.6666666666666667rem;
 }
 
-.c11 {
+.c12 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -53,19 +53,19 @@ exports[`MobileNavbar renders correctly 1`] = `
   color: currentColor;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   opacity: 0.8;
 }
 
-.c11:active {
+.c12:active {
   -webkit-transform: scale(0.95);
   -ms-transform: scale(0.95);
   transform: scale(0.95);
   opacity: 0.6;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -79,7 +79,7 @@ exports[`MobileNavbar renders correctly 1`] = `
   flex: 1 1 auto;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -92,37 +92,37 @@ exports[`MobileNavbar renders correctly 1`] = `
   cursor: pointer;
 }
 
-.c15:last-child {
+.c16:last-child {
   margin-right: 0;
 }
 
-.c15:hover,
-.c15:focus {
+.c16:hover,
+.c16:focus {
   opacity: 0.8;
 }
 
-.c15:active {
+.c16:active {
   -webkit-transform: scale(0.95);
   -ms-transform: scale(0.95);
   transform: scale(0.95);
   opacity: 0.6;
 }
 
-.c15 svg path {
+.c16 svg path {
   fill: currentColor;
 }
 
-.c16 {
+.c17 {
   width: 0.7777777777777778rem;
   height: 0.7777777777777778rem;
 }
 
-.c17.c17 {
+.c18.c18 {
   width: NaNrem;
   height: 1rem;
 }
 
-.c4 {
+.c5 {
   display: inline-block;
   vertical-align: middle;
   box-sizing: border-box;
@@ -133,7 +133,7 @@ exports[`MobileNavbar renders correctly 1`] = `
   height: 1.6666666666666667rem;
 }
 
-.c1 {
+.c2 {
   background: none;
   outline: none;
   border: none;
@@ -148,11 +148,11 @@ exports[`MobileNavbar renders correctly 1`] = `
   vertical-align: middle;
 }
 
-.c1 + {
+.c2 + .c1 {
   padding-left: 0;
 }
 
-.c5 {
+.c6 {
   background: none;
   outline: none;
   border: none;
@@ -167,7 +167,7 @@ exports[`MobileNavbar renders correctly 1`] = `
   vertical-align: middle;
 }
 
-.c5 + {
+.c6 + .c1 {
   padding-left: 0;
 }
 
@@ -175,7 +175,7 @@ exports[`MobileNavbar renders correctly 1`] = `
   display: none;
 }
 
-.c9 {
+.c10 {
   position: absolute;
   top: 2.7777777777777777rem;
   left: 0;
@@ -210,12 +210,12 @@ exports[`MobileNavbar renders correctly 1`] = `
   color: #868686;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   vertical-align: center;
 }
 
-.c7 {
+.c8 {
   -webkit-transition: -webkit-transform 0.2s;
   -webkit-transition: transform 0.2s;
   transition: transform 0.2s;
@@ -227,16 +227,16 @@ exports[`MobileNavbar renders correctly 1`] = `
   transform: rotate(180deg);
 }
 
-.c13 {
+.c14 {
   padding-right: 1.1111111111111112rem;
 }
 
-.c6.c6 {
+.c7.c7 {
   width: 1.5555555555555556rem;
   height: 1.5555555555555556rem;
 }
 
-.c8.c8 {
+.c9.c9 {
   width: 2rem;
   height: 2rem;
 }
@@ -263,10 +263,10 @@ exports[`MobileNavbar renders correctly 1`] = `
   className="c0"
 >
   <button
-    className="c1"
+    className="c1 c2"
   >
     <svg
-      className="c2"
+      className="c3"
       height="15"
       width="15"
       xmlns="http://www.w3.org/2000/svg"
@@ -290,64 +290,64 @@ exports[`MobileNavbar renders correctly 1`] = `
   </button>
   <a
     aria-label="styled components"
-    className="c3"
+    className="c4"
     href="/"
     onClick={[Function]}
   >
     <div
-      className="c4"
+      className="c5"
     />
   </a>
   <div>
     <button
-      className="c5"
+      className="c1 c6"
     >
       <svg
-        className="c6"
+        className="c7"
         size={28}
       />
     </button>
     <button
-      className="c1"
+      className="c1 c2"
     >
       <div
-        className="c7"
+        className="c8"
       >
         <div
-          className="c8"
+          className="c9"
           size={36}
         />
       </div>
     </button>
   </div>
   <div
-    className="c9"
+    className="c10"
   >
     <nav
-      className="c10"
+      className="c11"
     >
       <a
-        className="c11"
+        className="c12"
         href="/docs"
         onClick={[Function]}
       >
         Documentation
       </a>
       <span
-        className="c12"
+        className="c13"
       />
       <a
-        className="c11"
+        className="c12"
         href="/ecosystem"
         onClick={[Function]}
       >
         Ecosystem
       </a>
       <span
-        className="c12"
+        className="c13"
       />
       <a
-        className="c11"
+        className="c12"
         href="/releases"
         onClick={[Function]}
       >
@@ -355,18 +355,18 @@ exports[`MobileNavbar renders correctly 1`] = `
       </a>
     </nav>
     <div
-      className="c13"
+      className="c14"
     >
       <nav
-        className="c14"
+        className="c15"
       >
         <a
-          className="c15"
+          className="c16"
           href="https://spectrum.chat/styled-components/"
           onClick={[Function]}
         >
           <svg
-            className="c16"
+            className="c17"
             height="14"
             viewBox="0 0 15 15"
             width="14"
@@ -381,22 +381,22 @@ exports[`MobileNavbar renders correctly 1`] = `
           </svg>
         </a>
         <a
-          className="c15"
+          className="c16"
           href="https://github.com/styled-components"
           onClick={[Function]}
         >
           <svg
-            className="c17"
+            className="c18"
             height="18"
           />
         </a>
         <a
-          className="c15"
+          className="c16"
           href="https://medium.com/styled-components"
           onClick={[Function]}
         >
           <svg
-            className="c17"
+            className="c18"
             height="18"
           />
         </a>

--- a/test/components/NavBar/__snapshots__/NavButton.spec.js.snap
+++ b/test/components/NavBar/__snapshots__/NavButton.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NavButton renders correctly 1`] = `
-.c0 {
+.c1 {
   background: none;
   outline: none;
   border: none;
@@ -16,11 +16,11 @@ exports[`NavButton renders correctly 1`] = `
   vertical-align: middle;
 }
 
-.c0 + {
+.c1 + .c0 {
   padding-left: 0;
 }
 
 <button
-  className="c0"
+  className="c0 c1"
 />
 `;

--- a/test/components/NavBar/__snapshots__/Navbar.spec.js.snap
+++ b/test/components/NavBar/__snapshots__/Navbar.spec.js.snap
@@ -125,7 +125,7 @@ exports[`Navbar renders correctly 1`] = `
   height: 2.2222222222222223rem;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   vertical-align: middle;
   box-sizing: border-box;
@@ -136,15 +136,15 @@ exports[`Navbar renders correctly 1`] = `
   height: 1.6666666666666667rem;
 }
 
-.c24 svg {
+.c25 svg {
   display: inline-block;
 }
 
-.c24 svg path {
+.c25 svg path {
   fill: currentColor;
 }
 
-.c23 {
+.c24 {
   background: none;
   outline: none;
   border: none;
@@ -159,11 +159,11 @@ exports[`Navbar renders correctly 1`] = `
   vertical-align: middle;
 }
 
-.c23 + {
+.c24 + .c23 {
   padding-left: 0;
 }
 
-.c27 {
+.c28 {
   background: none;
   outline: none;
   border: none;
@@ -178,7 +178,7 @@ exports[`Navbar renders correctly 1`] = `
   vertical-align: middle;
 }
 
-.c27 + {
+.c28 + .c23 {
   padding-left: 0;
 }
 
@@ -186,7 +186,7 @@ exports[`Navbar renders correctly 1`] = `
   display: none;
 }
 
-.c31 {
+.c32 {
   position: absolute;
   top: 2.7777777777777777rem;
   left: 0;
@@ -221,12 +221,12 @@ exports[`Navbar renders correctly 1`] = `
   color: #868686;
 }
 
-.c25 {
+.c26 {
   display: inline-block;
   vertical-align: center;
 }
 
-.c29 {
+.c30 {
   -webkit-transition: -webkit-transform 0.2s;
   -webkit-transition: transform 0.2s;
   transition: transform 0.2s;
@@ -238,16 +238,16 @@ exports[`Navbar renders correctly 1`] = `
   transform: rotate(180deg);
 }
 
-.c32 {
+.c33 {
   padding-right: 1.1111111111111112rem;
 }
 
-.c28.c28 {
+.c29.c29 {
   width: 1.5555555555555556rem;
   height: 1.5555555555555556rem;
 }
 
-.c30.c30 {
+.c31.c31 {
   width: 2rem;
   height: 2rem;
 }
@@ -719,10 +719,10 @@ exports[`Navbar renders correctly 1`] = `
     className="c22"
   >
     <button
-      className="c23"
+      className="c23 c24"
     >
       <svg
-        className="c24"
+        className="c25"
         height="15"
         width="15"
         xmlns="http://www.w3.org/2000/svg"
@@ -746,39 +746,39 @@ exports[`Navbar renders correctly 1`] = `
     </button>
     <a
       aria-label="styled components"
-      className="c25"
+      className="c26"
       href="/"
       onClick={[Function]}
     >
       <div
-        className="c26"
+        className="c27"
       />
     </a>
     <div>
       <button
-        className="c27"
+        className="c23 c28"
         onClick={[Function]}
       >
         <svg
-          className="c28"
+          className="c29"
           size={28}
         />
       </button>
       <button
-        className="c23"
+        className="c23 c24"
       >
         <div
-          className="c29"
+          className="c30"
         >
           <div
-            className="c30"
+            className="c31"
             size={36}
           />
         </div>
       </button>
     </div>
     <div
-      className="c31"
+      className="c32"
     >
       <nav
         className="c5"
@@ -812,7 +812,7 @@ exports[`Navbar renders correctly 1`] = `
         </a>
       </nav>
       <div
-        className="c32"
+        className="c33"
       >
         <nav
           className="c17"

--- a/test/components/NavBar/__snapshots__/index.spec.js.snap
+++ b/test/components/NavBar/__snapshots__/index.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Nav renders correctly 1`] = `
-.c37 {
+.c38 {
   display: inline-block;
   color: inherit;
   cursor: pointer;
@@ -133,7 +133,7 @@ exports[`Nav renders correctly 1`] = `
   height: 2.2222222222222223rem;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   vertical-align: middle;
   box-sizing: border-box;
@@ -144,15 +144,15 @@ exports[`Nav renders correctly 1`] = `
   height: 1.6666666666666667rem;
 }
 
-.c24 svg {
+.c25 svg {
   display: inline-block;
 }
 
-.c24 svg path {
+.c25 svg path {
   fill: currentColor;
 }
 
-.c23 {
+.c24 {
   background: none;
   outline: none;
   border: none;
@@ -167,11 +167,11 @@ exports[`Nav renders correctly 1`] = `
   vertical-align: middle;
 }
 
-.c23 + {
+.c24 + .c23 {
   padding-left: 0;
 }
 
-.c27 {
+.c28 {
   background: none;
   outline: none;
   border: none;
@@ -186,7 +186,7 @@ exports[`Nav renders correctly 1`] = `
   vertical-align: middle;
 }
 
-.c27 + {
+.c28 + .c23 {
   padding-left: 0;
 }
 
@@ -194,7 +194,7 @@ exports[`Nav renders correctly 1`] = `
   display: none;
 }
 
-.c31 {
+.c32 {
   position: absolute;
   top: 2.7777777777777777rem;
   left: 0;
@@ -229,12 +229,12 @@ exports[`Nav renders correctly 1`] = `
   color: #868686;
 }
 
-.c25 {
+.c26 {
   display: inline-block;
   vertical-align: center;
 }
 
-.c29 {
+.c30 {
   -webkit-transition: -webkit-transform 0.2s;
   -webkit-transition: transform 0.2s;
   transition: transform 0.2s;
@@ -246,16 +246,16 @@ exports[`Nav renders correctly 1`] = `
   transform: rotate(180deg);
 }
 
-.c32 {
+.c33 {
   padding-right: 1.1111111111111112rem;
 }
 
-.c28.c28 {
+.c29.c29 {
   width: 1.5555555555555556rem;
   height: 1.5555555555555556rem;
 }
 
-.c30.c30 {
+.c31.c31 {
   width: 2rem;
   height: 2rem;
 }
@@ -459,7 +459,7 @@ exports[`Nav renders correctly 1`] = `
   margin-right: 1.9444444444444444rem;
 }
 
-.c33 {
+.c34 {
   position: fixed;
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
@@ -481,29 +481,29 @@ exports[`Nav renders correctly 1`] = `
   transition: transform 150ms ease-out;
 }
 
-.c34 {
+.c35 {
   display: block;
   box-sizing: border-box;
   height: 100%;
   padding-top: 1.3888888888888888rem;
 }
 
-.c35 {
+.c36 {
   margin-bottom: 1.1111111111111112rem;
 }
 
-.c36 {
+.c37 {
   display: block;
   margin: 0.5555555555555556rem 2.2222222222222223rem;
   font-weight: normal;
 }
 
 @media (min-width:62.5em) {
-  .c37 {
+  .c38 {
     border-radius: 0.16666666666666666rem;
   }
 
-  .c37:hover {
+  .c38:hover {
     background: rgba(20,20,20,0.1);
   }
 }
@@ -994,7 +994,7 @@ exports[`Nav renders correctly 1`] = `
                   active={true}
                 >
                   <button
-                    className="c23"
+                    className="c23 c24"
                   >
                     <CloseIcon>
                       <styled.svg
@@ -1004,7 +1004,7 @@ exports[`Nav renders correctly 1`] = `
                         xmlnsXlink="http://www.w3.org/1999/xlink"
                       >
                         <svg
-                          className="c24"
+                          className="c25"
                           height="15"
                           width="15"
                           xmlns="http://www.w3.org/2000/svg"
@@ -1032,7 +1032,7 @@ exports[`Nav renders correctly 1`] = `
                 <Styled(Link)>
                   <Link
                     aria-label="styled components"
-                    className="c25"
+                    className="c26"
                     href="/"
                     unstyled={true}
                   >
@@ -1041,7 +1041,7 @@ exports[`Nav renders correctly 1`] = `
                     >
                       <a
                         aria-label="styled components"
-                        className="c25"
+                        className="c26"
                         href="/"
                         onClick={[Function]}
                       >
@@ -1049,7 +1049,7 @@ exports[`Nav renders correctly 1`] = `
                           compact={true}
                         >
                           <div
-                            className="c26"
+                            className="c27"
                           />
                         </styled.div>
                       </a>
@@ -1061,7 +1061,7 @@ exports[`Nav renders correctly 1`] = `
                     onClick={[Function]}
                   >
                     <button
-                      className="c27"
+                      className="c23 c28"
                       onClick={[Function]}
                     >
                       <styled.div
@@ -1069,11 +1069,11 @@ exports[`Nav renders correctly 1`] = `
                         size={28}
                       >
                         <DummyIcon
-                          className="c28"
+                          className="c29"
                           size={28}
                         >
                           <svg
-                            className="c28"
+                            className="c29"
                             size={28}
                           />
                         </DummyIcon>
@@ -1084,19 +1084,19 @@ exports[`Nav renders correctly 1`] = `
                     active={true}
                   >
                     <button
-                      className="c23"
+                      className="c23 c24"
                     >
                       <styled.div
                         shouldRotate={true}
                       >
                         <div
-                          className="c29"
+                          className="c30"
                         >
                           <styled.div
                             size={36}
                           >
                             <div
-                              className="c30"
+                              className="c31"
                               size={36}
                             />
                           </styled.div>
@@ -1109,7 +1109,7 @@ exports[`Nav renders correctly 1`] = `
                   isOpen={true}
                 >
                   <div
-                    className="c31"
+                    className="c32"
                   >
                     <NavLinks>
                       <styled.nav>
@@ -1200,7 +1200,7 @@ exports[`Nav renders correctly 1`] = `
                     </NavLinks>
                     <styled.div>
                       <div
-                        className="c32"
+                        className="c33"
                       >
                         <Social>
                           <styled.nav>
@@ -1333,26 +1333,26 @@ exports[`Nav renders correctly 1`] = `
     <CaptureScroll>
       <styled.nav>
         <nav
-          className="c33"
+          className="c34"
         >
           <withRouter(Unknown)>
             <Component>
               <styled.div>
                 <div
-                  className="c34"
+                  className="c35"
                 >
                   <Folder
                     key="Basics"
                   >
                     <styled.div>
                       <div
-                        className="c35"
+                        className="c36"
                       >
                         <styled.h4
                           onClick={[Function]}
                         >
                           <h4
-                            className="c36"
+                            className="c37"
                             onClick={[Function]}
                           >
                             <Link
@@ -1366,7 +1366,7 @@ exports[`Nav renders correctly 1`] = `
                                   onClick={[Function]}
                                 >
                                   <a
-                                    className="c37"
+                                    className="c38"
                                     href="/docs/basics"
                                     onClick={[Function]}
                                   >
@@ -1385,13 +1385,13 @@ exports[`Nav renders correctly 1`] = `
                   >
                     <styled.div>
                       <div
-                        className="c35"
+                        className="c36"
                       >
                         <styled.h4
                           onClick={[Function]}
                         >
                           <h4
-                            className="c36"
+                            className="c37"
                             onClick={[Function]}
                           >
                             <Link
@@ -1405,7 +1405,7 @@ exports[`Nav renders correctly 1`] = `
                                   onClick={[Function]}
                                 >
                                   <a
-                                    className="c37"
+                                    className="c38"
                                     href="/docs/advanced"
                                     onClick={[Function]}
                                   >
@@ -1424,13 +1424,13 @@ exports[`Nav renders correctly 1`] = `
                   >
                     <styled.div>
                       <div
-                        className="c35"
+                        className="c36"
                       >
                         <styled.h4
                           onClick={[Function]}
                         >
                           <h4
-                            className="c36"
+                            className="c37"
                             onClick={[Function]}
                           >
                             <Link
@@ -1444,7 +1444,7 @@ exports[`Nav renders correctly 1`] = `
                                   onClick={[Function]}
                                 >
                                   <a
-                                    className="c37"
+                                    className="c38"
                                     href="/docs/api"
                                     onClick={[Function]}
                                   >
@@ -1463,13 +1463,13 @@ exports[`Nav renders correctly 1`] = `
                   >
                     <styled.div>
                       <div
-                        className="c35"
+                        className="c36"
                       >
                         <styled.h4
                           onClick={[Function]}
                         >
                           <h4
-                            className="c36"
+                            className="c37"
                             onClick={[Function]}
                           >
                             <Link
@@ -1483,7 +1483,7 @@ exports[`Nav renders correctly 1`] = `
                                   onClick={[Function]}
                                 >
                                   <a
-                                    className="c37"
+                                    className="c38"
                                     href="/docs/tooling"
                                     onClick={[Function]}
                                   >
@@ -1502,13 +1502,13 @@ exports[`Nav renders correctly 1`] = `
                   >
                     <styled.div>
                       <div
-                        className="c35"
+                        className="c36"
                       >
                         <styled.h4
                           onClick={[Function]}
                         >
                           <h4
-                            className="c36"
+                            className="c37"
                             onClick={[Function]}
                           >
                             <Link
@@ -1522,7 +1522,7 @@ exports[`Nav renders correctly 1`] = `
                                   onClick={[Function]}
                                 >
                                   <a
-                                    className="c37"
+                                    className="c38"
                                     href="/docs/faqs"
                                     onClick={[Function]}
                                   >

--- a/test/components/__snapshots__/DocsLayout.spec.js.snap
+++ b/test/components/__snapshots__/DocsLayout.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DocsLayout renders correctly 1`] = `
-.c37 {
+.c38 {
   display: inline-block;
   color: inherit;
   cursor: pointer;
@@ -133,7 +133,7 @@ exports[`DocsLayout renders correctly 1`] = `
   height: 2.2222222222222223rem;
 }
 
-.c27 {
+.c28 {
   display: inline-block;
   vertical-align: middle;
   box-sizing: border-box;
@@ -144,15 +144,15 @@ exports[`DocsLayout renders correctly 1`] = `
   height: 1.6666666666666667rem;
 }
 
-.c25 svg {
+.c26 svg {
   display: inline-block;
 }
 
-.c25 svg path {
+.c26 svg path {
   fill: currentColor;
 }
 
-.c24 {
+.c25 {
   background: none;
   outline: none;
   border: none;
@@ -167,7 +167,7 @@ exports[`DocsLayout renders correctly 1`] = `
   vertical-align: middle;
 }
 
-.c24 + {
+.c25 + .c24 {
   padding-left: 0;
 }
 
@@ -175,7 +175,7 @@ exports[`DocsLayout renders correctly 1`] = `
   display: none;
 }
 
-.c31 {
+.c32 {
   position: absolute;
   top: 2.7777777777777777rem;
   left: 0;
@@ -210,27 +210,27 @@ exports[`DocsLayout renders correctly 1`] = `
   color: #868686;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   vertical-align: center;
 }
 
-.c29 {
+.c30 {
   -webkit-transition: -webkit-transform 0.2s;
   -webkit-transition: transform 0.2s;
   transition: transform 0.2s;
 }
 
-.c32 {
+.c33 {
   padding-right: 1.1111111111111112rem;
 }
 
-.c28.c28 {
+.c29.c29 {
   width: 1.5555555555555556rem;
   height: 1.5555555555555556rem;
 }
 
-.c30.c30 {
+.c31.c31 {
   width: 2rem;
   height: 2rem;
 }
@@ -434,7 +434,7 @@ exports[`DocsLayout renders correctly 1`] = `
   margin-right: 1.9444444444444444rem;
 }
 
-.c33 {
+.c34 {
   position: fixed;
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
@@ -456,18 +456,18 @@ exports[`DocsLayout renders correctly 1`] = `
   transition: transform 150ms ease-out;
 }
 
-.c34 {
+.c35 {
   display: block;
   box-sizing: border-box;
   height: 100%;
   padding-top: 1.3888888888888888rem;
 }
 
-.c35 {
+.c36 {
   margin-bottom: 1.1111111111111112rem;
 }
 
-.c36 {
+.c37 {
   display: block;
   margin: 0.5555555555555556rem 2.2222222222222223rem;
   font-weight: normal;
@@ -477,7 +477,7 @@ exports[`DocsLayout renders correctly 1`] = `
   padding-left: 16.666666666666668rem;
 }
 
-.c38 {
+.c39 {
   width: 56.888888888888886rem;
   max-width: 100%;
   margin: 0 auto;
@@ -489,7 +489,7 @@ exports[`DocsLayout renders correctly 1`] = `
   transition: transform 150ms ease-out;
 }
 
-.c39 {
+.c40 {
   display: block;
   text-align: left;
   width: 100%;
@@ -500,11 +500,11 @@ exports[`DocsLayout renders correctly 1`] = `
 }
 
 @media (min-width:62.5em) {
-  .c37 {
+  .c38 {
     border-radius: 0.16666666666666666rem;
   }
 
-  .c37:hover {
+  .c38:hover {
     background: rgba(20,20,20,0.1);
   }
 }
@@ -635,7 +635,7 @@ exports[`DocsLayout renders correctly 1`] = `
 }
 
 @media (max-width:62.5em) {
-  .c33 {
+  .c34 {
     -webkit-transform: translateX(-16.666666666666668rem);
     -ms-transform: translateX(-16.666666666666668rem);
     transform: translateX(-16.666666666666668rem);
@@ -649,7 +649,7 @@ exports[`DocsLayout renders correctly 1`] = `
 }
 
 @media (max-width:62.5em) {
-  .c38 {
+  .c39 {
     padding: 3.888888888888889rem 1.1111111111111112rem 1.6666666666666667rem 1.1111111111111112rem;
     -webkit-transform: translateX(0);
     -ms-transform: translateX(0);
@@ -1051,7 +1051,7 @@ exports[`DocsLayout renders correctly 1`] = `
                         onClick={[Function]}
                       >
                         <button
-                          className="c24"
+                          className="c24 c25"
                           onClick={[Function]}
                         >
                           <FoldIcon>
@@ -1062,7 +1062,7 @@ exports[`DocsLayout renders correctly 1`] = `
                               xmlnsXlink="http://www.w3.org/1999/xlink"
                             >
                               <svg
-                                className="c25"
+                                className="c26"
                                 height="14"
                                 width="17"
                                 xmlns="http://www.w3.org/2000/svg"
@@ -1090,7 +1090,7 @@ exports[`DocsLayout renders correctly 1`] = `
                       <Styled(Link)>
                         <Link
                           aria-label="styled components"
-                          className="c26"
+                          className="c27"
                           href="/"
                           unstyled={true}
                         >
@@ -1099,7 +1099,7 @@ exports[`DocsLayout renders correctly 1`] = `
                           >
                             <a
                               aria-label="styled components"
-                              className="c26"
+                              className="c27"
                               href="/"
                               onClick={[Function]}
                             >
@@ -1107,7 +1107,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                 compact={true}
                               >
                                 <div
-                                  className="c27"
+                                  className="c28"
                                 />
                               </styled.div>
                             </a>
@@ -1119,7 +1119,7 @@ exports[`DocsLayout renders correctly 1`] = `
                           onClick={[Function]}
                         >
                           <button
-                            className="c24"
+                            className="c24 c25"
                             onClick={[Function]}
                           >
                             <styled.div
@@ -1127,11 +1127,11 @@ exports[`DocsLayout renders correctly 1`] = `
                               size={28}
                             >
                               <DummyIcon
-                                className="c28"
+                                className="c29"
                                 size={28}
                               >
                                 <svg
-                                  className="c28"
+                                  className="c29"
                                   size={28}
                                 />
                               </DummyIcon>
@@ -1143,20 +1143,20 @@ exports[`DocsLayout renders correctly 1`] = `
                           onClick={[Function]}
                         >
                           <button
-                            className="c24"
+                            className="c24 c25"
                             onClick={[Function]}
                           >
                             <styled.div
                               shouldRotate={false}
                             >
                               <div
-                                className="c29"
+                                className="c30"
                               >
                                 <styled.div
                                   size={36}
                                 >
                                   <div
-                                    className="c30"
+                                    className="c31"
                                     size={36}
                                   />
                                 </styled.div>
@@ -1169,7 +1169,7 @@ exports[`DocsLayout renders correctly 1`] = `
                         isOpen={false}
                       >
                         <div
-                          className="c31"
+                          className="c32"
                         >
                           <NavLinks>
                             <styled.nav>
@@ -1260,7 +1260,7 @@ exports[`DocsLayout renders correctly 1`] = `
                           </NavLinks>
                           <styled.div>
                             <div
-                              className="c32"
+                              className="c33"
                             >
                               <Social>
                                 <styled.nav>
@@ -1397,7 +1397,7 @@ exports[`DocsLayout renders correctly 1`] = `
               isFolded={true}
             >
               <nav
-                className="c33"
+                className="c34"
               >
                 <withRouter(Unknown)
                   onRouteChange={[Function]}
@@ -1407,7 +1407,7 @@ exports[`DocsLayout renders correctly 1`] = `
                   >
                     <styled.div>
                       <div
-                        className="c34"
+                        className="c35"
                       >
                         <Folder
                           key="Basics"
@@ -1416,14 +1416,14 @@ exports[`DocsLayout renders correctly 1`] = `
                             onClick={[Function]}
                           >
                             <div
-                              className="c35"
+                              className="c36"
                               onClick={[Function]}
                             >
                               <styled.h4
                                 onClick={[Function]}
                               >
                                 <h4
-                                  className="c36"
+                                  className="c37"
                                   onClick={[Function]}
                                 >
                                   <Link
@@ -1437,7 +1437,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                         onClick={[Function]}
                                       >
                                         <a
-                                          className="c37"
+                                          className="c38"
                                           href="/docs/basics"
                                           onClick={[Function]}
                                         >
@@ -1458,14 +1458,14 @@ exports[`DocsLayout renders correctly 1`] = `
                             onClick={[Function]}
                           >
                             <div
-                              className="c35"
+                              className="c36"
                               onClick={[Function]}
                             >
                               <styled.h4
                                 onClick={[Function]}
                               >
                                 <h4
-                                  className="c36"
+                                  className="c37"
                                   onClick={[Function]}
                                 >
                                   <Link
@@ -1479,7 +1479,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                         onClick={[Function]}
                                       >
                                         <a
-                                          className="c37"
+                                          className="c38"
                                           href="/docs/advanced"
                                           onClick={[Function]}
                                         >
@@ -1500,14 +1500,14 @@ exports[`DocsLayout renders correctly 1`] = `
                             onClick={[Function]}
                           >
                             <div
-                              className="c35"
+                              className="c36"
                               onClick={[Function]}
                             >
                               <styled.h4
                                 onClick={[Function]}
                               >
                                 <h4
-                                  className="c36"
+                                  className="c37"
                                   onClick={[Function]}
                                 >
                                   <Link
@@ -1521,7 +1521,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                         onClick={[Function]}
                                       >
                                         <a
-                                          className="c37"
+                                          className="c38"
                                           href="/docs/api"
                                           onClick={[Function]}
                                         >
@@ -1542,14 +1542,14 @@ exports[`DocsLayout renders correctly 1`] = `
                             onClick={[Function]}
                           >
                             <div
-                              className="c35"
+                              className="c36"
                               onClick={[Function]}
                             >
                               <styled.h4
                                 onClick={[Function]}
                               >
                                 <h4
-                                  className="c36"
+                                  className="c37"
                                   onClick={[Function]}
                                 >
                                   <Link
@@ -1563,7 +1563,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                         onClick={[Function]}
                                       >
                                         <a
-                                          className="c37"
+                                          className="c38"
                                           href="/docs/tooling"
                                           onClick={[Function]}
                                         >
@@ -1584,14 +1584,14 @@ exports[`DocsLayout renders correctly 1`] = `
                             onClick={[Function]}
                           >
                             <div
-                              className="c35"
+                              className="c36"
                               onClick={[Function]}
                             >
                               <styled.h4
                                 onClick={[Function]}
                               >
                                 <h4
-                                  className="c36"
+                                  className="c37"
                                   onClick={[Function]}
                                 >
                                   <Link
@@ -1605,7 +1605,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                         onClick={[Function]}
                                       >
                                         <a
-                                          className="c37"
+                                          className="c38"
                                           href="/docs/faqs"
                                           onClick={[Function]}
                                         >
@@ -1633,12 +1633,12 @@ exports[`DocsLayout renders correctly 1`] = `
         moveRight={false}
       >
         <div
-          className="c38"
+          className="c39"
           data-e2e-id="content"
         >
           <styled.h1>
             <h1
-              className="c39"
+              className="c40"
             />
           </styled.h1>
         </div>


### PR DESCRIPTION
Currently, this results in the following CSS:
```css
.c1 + { padding-left: 0; }
```

Why? `NavBar` is undefined at the time of usage, newer versions of Babel error for this.

After this change:
```css
.c2 + .c1 { padding-left: 0; }
```