### PR TITLE
Tooling Stylelint: improve setup instructions

### DIFF
--- a/sections/tooling/stylelint.md
+++ b/sections/tooling/stylelint.md
@@ -7,17 +7,17 @@ Lint your [styled components](https://github.com/styled-components/styled-compon
 You need:
 
 - `stylelint` (duh)
-- This processor, to extract styles from `styled-components`
+- The [stylelint-processor-styled-components](https://github.com/styled-components/stylelint-processor-styled-components), to extract styles from `styled-components`
 - The [`stylelint-config-styled-components`](https://github.com/styled-components/stylelint-config-styled-components) to disable stylelint rules that clash with `styled-components`
 - Your favorite `stylelint` config! (for example [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended))
 
 > We recommend using Stylelint v9+ as this has added features that allow us to report correct line numbers on CSS syntax errors
 
 ```
-(npm install --save-dev
-  stylelint
-  stylelint-processor-styled-components
-  stylelint-config-styled-components
+(npm install --save-dev \
+  stylelint \
+  stylelint-processor-styled-components \
+  stylelint-config-styled-components \
   stylelint-config-recommended)
 ```
 


### PR DESCRIPTION
It looks like the setup instructions for stylelint are partly a copy from the processor's readme, that's why I also files a similar PR there: https://github.com/styled-components/stylelint-processor-styled-components/pull/286 .
In this PR I additionally to the processor repo.