### PR TITLE
Do not assume it causes leak to fail to call ServerSideStyleSheet.seal

### DIFF
--- a/sections/advanced/server-side-rendering.md
+++ b/sections/advanced/server-side-rendering.md
@@ -25,15 +25,9 @@ import { renderToString } from 'react-dom/server'
 import { ServerStyleSheet } from 'styled-components'
 
 const sheet = new ServerStyleSheet()
-try {
-  const html = renderToString(sheet.collectStyles(<YourApp />))
-  const styleTags = sheet.getStyleTags() // or sheet.getStyleElement();
-} catch (error) {
-  // handle error
-  console.error(error)
-} finally {
-  sheet.seal()
-}
+const html = renderToString(sheet.collectStyles(<YourApp />))
+const styleTags = sheet.getStyleTags() // or sheet.getStyleElement();
+sheet.seal()
 ```
 
 The `collectStyles` method wraps your element in a provider. Optionally you can use
@@ -45,19 +39,13 @@ import { renderToString } from 'react-dom/server'
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components'
 
 const sheet = new ServerStyleSheet()
-try {
-  const html = renderToString(
-    <StyleSheetManager sheet={sheet.instance}>
-      <YourApp />
-    </StyleSheetManager>
-  )
-  const styleTags = sheet.getStyleTags() // or sheet.getStyleElement();
-} catch (error) {
-  // handle error
-  console.error(error)
-} finally {
-  sheet.seal()
-}
+const html = renderToString(
+  <StyleSheetManager sheet={sheet.instance}>
+    <YourApp />
+  </StyleSheetManager>
+)
+const styleTags = sheet.getStyleTags() // or sheet.getStyleElement();
+sheet.seal()
 ```
 
 The `sheet.getStyleTags()` returns a string of multiple `<style>` tags.
@@ -66,7 +54,8 @@ You need to take this into account when adding the CSS string to your HTML outpu
 Alternatively the `ServerStyleSheet` instance also has a `getStyleElement()` method
 that returns an array of React elements.
 
-If rendering fails for any reason it's a good idea to use `try...catch...finally` to ensure that the `sheet` object will always be available for garbage collection. Make sure `sheet.seal()` is only called after `sheet.getStyleTags()` or `sheet.getStyleElement()` have been called otherwise a different error will be thrown.
+`sheet.seal()` seals the instance and ensures all styles are already collected.
+Make sure it is only called after `sheet.getStyleTags()` or `sheet.getStyleElement()` have been called.
 
 > `sheet.getStyleTags()` and `sheet.getStyleElement()` can only be called after your element is rendered. As a result, components from `sheet.getStyleElement()` cannot be combined with `<YourApp />` into a larger component.
 


### PR DESCRIPTION
Commit 2c963286be9618fa802e6dc4020330d94046e930 removed `ServerSideStyleSheet.seal` and the necessity to call it to let garbage collector to collect an abandoned instance. Commit `97a637a038521e822568362849edd05652e557a3` reintroduced the method, but it is no longer necessary to make sure to call the method for that purpose.

The `finally` blocks in examples is now redundant and may hide an error in `try` blocks if they are incorrectly written. This change removes those blocks.

It also amends the description of the function of the method to reflect the current implementation.

Fixes #329.

# Question
This change also removes the `catch` blocks in examples, which were introduced when the documentation for `ServerSideStyleSheet.seal` was added. I think there is no real reason to have those blocks in examples because code to recover from errors are written in a greater block encapsulating statements shown in examples in real world. Readers can focus on how to use styled-components by removing those blocks. Still, please tell me if you think it is unfavorable. I'll revert the change in that case.