### PR TITLE
docs: clarify v5 attrs object-form deprecation

### DIFF
--- a/sections/faqs/migration-v5.md
+++ b/sections/faqs/migration-v5.md
@@ -24,7 +24,7 @@ styled-components v5 does not introduce any breaking public API changes, and add
   - `stylisPlugins`
     - try it with [`stylis-plugin-rtl`](https://www.npmjs.com/package/stylis-plugin-rtl) for your bidi needs!
 
-> Note: The object-form `.attrs({})` syntax that was deprecated in v4 is removed in v5. Use function-form attrs instead `.attrs(props => ({}))` (you should have been seeing console warnings to make this update ahead of time.)
+> Note: The subfunction object-form `.attrs({ prop: props => {} })` syntax that was deprecated in v4 is removed in v5. Use function-form attrs instead `.attrs(props => ({}))` (you should have been seeing console warnings to make this update ahead of time.)
 
 Check out the [official announcement post](https://medium.com/styled-components/389747abd987) for more information and to learn about what went into v5!
 


### PR DESCRIPTION
Clarifies the note that the `attrs` object-form removal in v5 was only for the subfunction support, not the object-form itself, which is still supported.