### PR TITLE
Update react-native.md Broken URL

### DIFF
--- a/sections/basics/react-native.md
+++ b/sections/basics/react-native.md
@@ -57,4 +57,4 @@ nest your CSS.
 
 ### Simpler usage with the metro bundler
 
-If you'd prefer to just import `styled-components` instead of `styled-components/native`, you can add a [`resolverMainFields` configuration](https://facebook.github.io/metro/docs/en/configuration.html#resolver-options) that includes `"react-native"`. This used to be supported in metro by default (and currently does work in haul) but appears to have been removed at some point.
+If you'd prefer to just import `styled-components` instead of `styled-components/native`, you can add a [`resolverMainFields` configuration](https://facebook.github.io/metro/docs/configuration#resolvermainfields) that includes `"react-native"`. This used to be supported in metro by default (and currently does work in haul) but appears to have been removed at some point.


### PR DESCRIPTION
Pre-Change: URL was Broken
Post-Change: URL now directs to correct source.