### PR TITLE
Add react-is dependency for CDN installation

### DIFF
--- a/sections/basics/installation.md
+++ b/sections/basics/installation.md
@@ -25,6 +25,6 @@ const Component = window.styled.div`
 `
 ```
 
-> This style of usage requires the [react CDN bundles](https://reactjs.org/docs/cdn-links.html) to be on the page as well (before the styled-components script.)
+> This style of usage requires the [react CDN bundles](https://reactjs.org/docs/cdn-links.html) and the [`react-is` CDN bundle](https://unpkg.com/react-is/umd/react-is.production.min.js) to be on the page as well (before the styled-components script.)
 
 </details>


### PR DESCRIPTION
Hello,

In your docs here https://styled-components.com/docs/basics#installation in the CDN part, you mention the `<script>` tag to add:
```html
<script src="https://unpkg.com/styled-components/dist/styled-components.min.js"></script>
```
You also mention to put it after the React CDN bundles with a [link](https://reactjs.org/docs/cdn-links.html) to them.

Since last version of styled components, there is a new (production-) dependency on `react-is` pacakge.

So doing this:
```html
<script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
<script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
<script crossorigin src="https://unpkg.com/styled-components/dist/styled-components.min.js"></script>
```

Results in the following error:
```
Uncaught TypeError: Cannot use 'in' operator to search for 'default' in undefined
    at styled-components.min.js:1
    at styled-components.min.js:1
    at styled-components.min.js:1
```
I think you should also mention to add a CDN `<script>` tag for `react-is` like this one:
```html
<script crossorigin src="https://unpkg.com/react-is/umd/react-is.production.min.js"></script>
```
so you end up having these:
```html
<script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
<script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
<script crossorigin src="https://unpkg.com/react-is/umd/react-is.production.min.js"></script>
<script crossorigin src="https://unpkg.com/styled-components/dist/styled-components.min.js"></script>
```

And now everything works!