### PR TITLE
Add theming example with object notation

### DIFF
--- a/sections/advanced/theming.md
+++ b/sections/advanced/theming.md
@@ -20,6 +20,7 @@ const Button = styled.button`
   border: 2px solid ${props => props.theme.main};
 `;
 
+
 // We are passing a default theme for Buttons that arent wrapped in the ThemeProvider
 Button.defaultProps = {
   theme: {
@@ -41,6 +42,14 @@ render(
     </ThemeProvider>
   </div>
 );
+```
+
+```
+// Example with object notation:
+const HighlightedSpan = Styled.Text(props => ({
+    color: props.theme.highlightTextColor,
+}));
+
 ```
 
 ### Function themes


### PR DESCRIPTION
Couldn't find this documented anywhere - we use exclusively object notation in our React Native project.  

This is fairly intuitive but should be explicitly documented.  Thanks!