### PR TITLE
Vertically center "Discover more" text 

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -133,7 +133,6 @@ const Links = styled.div`
 `;
 
 const ShowcaseLink = styled(NextLink)`
-  height: 48px;
   display: block;
   max-width: 100%;
   width: 196px;


### PR DESCRIPTION
Hi! I noticed the text in the "Discover more" button wasn't centered and I couldn't resist to center it.

Before:
![image](https://user-images.githubusercontent.com/1911623/80892943-798c8980-8ca4-11ea-90e4-ff6043c22e72.png)

After:
![image](https://user-images.githubusercontent.com/1911623/80892950-87daa580-8ca4-11ea-95d1-86ae2c736d38.png)
