### PR TITLE
Updated outbound links to use standard anchor tags.

### DIFF
--- a/components/Footer/index.js
+++ b/components/Footer/index.js
@@ -4,7 +4,6 @@ import { Favorite } from '@styled-icons/material';
 import rem from '../../utils/rem';
 import { mobile } from '../../utils/media';
 import { grey, paleGrey, red } from '../../utils/colors';
-import Link from '../Link';
 import { Content } from '../Layout';
 
 const Wrapper = styled.footer`
@@ -26,7 +25,7 @@ const Heart = styled(Favorite)`
   transform: translateY(-10%);
 `;
 
-const FooterLink = styled(Link)`
+const FooterLink = styled.a`
   color: ${grey};
 `;
 

--- a/components/Nav/Social.js
+++ b/components/Nav/Social.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { Github, MediumM } from '@styled-icons/fa-brands';
 import rem from '../../utils/rem';
 import { navbarHeight } from '../../utils/sizes';
-import Link from '../Link';
 
 const Wrapper = styled.nav`
   display: flex;
@@ -11,7 +10,7 @@ const Wrapper = styled.nav`
   flex: 1 1 auto;
 `;
 
-const SocialLink = styled(Link).attrs((/* props */) => ({
+const SocialLink = styled.a.attrs((/* props */) => ({
   unstyled: true,
 }))`
   display: flex;

--- a/test/components/NavBar/__snapshots__/index.spec.js.snap
+++ b/test/components/NavBar/__snapshots__/index.spec.js.snap
@@ -921,113 +921,83 @@ exports[`Nav renders correctly 1`] = `
                         <nav
                           className="c21 c20 "
                         >
-                          <Styled(Link)
+                          <styled.a
                             href="https://spectrum.chat/styled-components/"
                           >
-                            <Link
+                            <a
                               className="c22"
                               href="https://spectrum.chat/styled-components/"
-                              unstyled={true}
                             >
-                              <Link
-                                href="https://spectrum.chat/styled-components/"
-                              >
-                                <a
-                                  className="c22"
-                                  href="https://spectrum.chat/styled-components/"
+                              <Spectrum>
+                                <styled.svg
+                                  height="14"
+                                  viewBox="0 0 15 15"
+                                  width="14"
                                 >
-                                  <Spectrum>
-                                    <styled.svg
-                                      height="14"
-                                      viewBox="0 0 15 15"
-                                      width="14"
-                                    >
-                                      <svg
-                                        className="c23"
-                                        height="14"
-                                        viewBox="0 0 15 15"
-                                        width="14"
-                                      >
-                                        <title>
-                                          spectrum
-                                        </title>
-                                        <path
-                                          d="M0 6.5V1c0-.6.4-1 1-1 9 .3 13.7 5 14 14 0 .6-.4 1-1 1H8.5c-.6 0-1-.4-1-1-.3-4.4-2-6.2-6.5-6.5-.6 0-1-.4-1-1z"
-                                          fill="#FFF"
-                                        />
-                                      </svg>
-                                    </styled.svg>
-                                  </Spectrum>
-                                </a>
-                              </Link>
-                            </Link>
-                          </Styled(Link)>
-                          <Styled(Link)
+                                  <svg
+                                    className="c23"
+                                    height="14"
+                                    viewBox="0 0 15 15"
+                                    width="14"
+                                  >
+                                    <title>
+                                      spectrum
+                                    </title>
+                                    <path
+                                      d="M0 6.5V1c0-.6.4-1 1-1 9 .3 13.7 5 14 14 0 .6-.4 1-1 1H8.5c-.6 0-1-.4-1-1-.3-4.4-2-6.2-6.5-6.5-.6 0-1-.4-1-1z"
+                                      fill="#FFF"
+                                    />
+                                  </svg>
+                                </styled.svg>
+                              </Spectrum>
+                            </a>
+                          </styled.a>
+                          <styled.a
                             href="https://github.com/styled-components"
                           >
-                            <Link
+                            <a
                               className="c22"
                               href="https://github.com/styled-components"
-                              unstyled={true}
                             >
-                              <Link
-                                href="https://github.com/styled-components"
+                              <styled.div
+                                as={[Function]}
+                                height="18"
                               >
-                                <a
-                                  className="c22"
-                                  href="https://github.com/styled-components"
+                                <DummyIcon
+                                  className="c24"
+                                  height="18"
                                 >
-                                  <styled.div
-                                    as={[Function]}
+                                  <svg
+                                    className="c24"
                                     height="18"
-                                  >
-                                    <DummyIcon
-                                      className="c24"
-                                      height="18"
-                                    >
-                                      <svg
-                                        className="c24"
-                                        height="18"
-                                      />
-                                    </DummyIcon>
-                                  </styled.div>
-                                </a>
-                              </Link>
-                            </Link>
-                          </Styled(Link)>
-                          <Styled(Link)
+                                  />
+                                </DummyIcon>
+                              </styled.div>
+                            </a>
+                          </styled.a>
+                          <styled.a
                             href="https://medium.com/styled-components"
                           >
-                            <Link
+                            <a
                               className="c22"
                               href="https://medium.com/styled-components"
-                              unstyled={true}
                             >
-                              <Link
-                                href="https://medium.com/styled-components"
+                              <styled.div
+                                as={[Function]}
+                                height="18"
                               >
-                                <a
-                                  className="c22"
-                                  href="https://medium.com/styled-components"
+                                <DummyIcon
+                                  className="c24"
+                                  height="18"
                                 >
-                                  <styled.div
-                                    as={[Function]}
+                                  <svg
+                                    className="c24"
                                     height="18"
-                                  >
-                                    <DummyIcon
-                                      className="c24"
-                                      height="18"
-                                    >
-                                      <svg
-                                        className="c24"
-                                        height="18"
-                                      />
-                                    </DummyIcon>
-                                  </styled.div>
-                                </a>
-                              </Link>
-                            </Link>
-                          </Styled(Link)>
+                                  />
+                                </DummyIcon>
+                              </styled.div>
+                            </a>
+                          </styled.a>
                         </nav>
                       </styled.nav>
                     </Social>
@@ -1275,113 +1245,83 @@ exports[`Nav renders correctly 1`] = `
                             <nav
                               className="c21"
                             >
-                              <Styled(Link)
+                              <styled.a
                                 href="https://spectrum.chat/styled-components/"
                               >
-                                <Link
+                                <a
                                   className="c22"
                                   href="https://spectrum.chat/styled-components/"
-                                  unstyled={true}
                                 >
-                                  <Link
-                                    href="https://spectrum.chat/styled-components/"
-                                  >
-                                    <a
-                                      className="c22"
-                                      href="https://spectrum.chat/styled-components/"
+                                  <Spectrum>
+                                    <styled.svg
+                                      height="14"
+                                      viewBox="0 0 15 15"
+                                      width="14"
                                     >
-                                      <Spectrum>
-                                        <styled.svg
-                                          height="14"
-                                          viewBox="0 0 15 15"
-                                          width="14"
-                                        >
-                                          <svg
-                                            className="c23"
-                                            height="14"
-                                            viewBox="0 0 15 15"
-                                            width="14"
-                                          >
-                                            <title>
-                                              spectrum
-                                            </title>
-                                            <path
-                                              d="M0 6.5V1c0-.6.4-1 1-1 9 .3 13.7 5 14 14 0 .6-.4 1-1 1H8.5c-.6 0-1-.4-1-1-.3-4.4-2-6.2-6.5-6.5-.6 0-1-.4-1-1z"
-                                              fill="#FFF"
-                                            />
-                                          </svg>
-                                        </styled.svg>
-                                      </Spectrum>
-                                    </a>
-                                  </Link>
-                                </Link>
-                              </Styled(Link)>
-                              <Styled(Link)
+                                      <svg
+                                        className="c23"
+                                        height="14"
+                                        viewBox="0 0 15 15"
+                                        width="14"
+                                      >
+                                        <title>
+                                          spectrum
+                                        </title>
+                                        <path
+                                          d="M0 6.5V1c0-.6.4-1 1-1 9 .3 13.7 5 14 14 0 .6-.4 1-1 1H8.5c-.6 0-1-.4-1-1-.3-4.4-2-6.2-6.5-6.5-.6 0-1-.4-1-1z"
+                                          fill="#FFF"
+                                        />
+                                      </svg>
+                                    </styled.svg>
+                                  </Spectrum>
+                                </a>
+                              </styled.a>
+                              <styled.a
                                 href="https://github.com/styled-components"
                               >
-                                <Link
+                                <a
                                   className="c22"
                                   href="https://github.com/styled-components"
-                                  unstyled={true}
                                 >
-                                  <Link
-                                    href="https://github.com/styled-components"
+                                  <styled.div
+                                    as={[Function]}
+                                    height="18"
                                   >
-                                    <a
-                                      className="c22"
-                                      href="https://github.com/styled-components"
+                                    <DummyIcon
+                                      className="c24"
+                                      height="18"
                                     >
-                                      <styled.div
-                                        as={[Function]}
+                                      <svg
+                                        className="c24"
                                         height="18"
-                                      >
-                                        <DummyIcon
-                                          className="c24"
-                                          height="18"
-                                        >
-                                          <svg
-                                            className="c24"
-                                            height="18"
-                                          />
-                                        </DummyIcon>
-                                      </styled.div>
-                                    </a>
-                                  </Link>
-                                </Link>
-                              </Styled(Link)>
-                              <Styled(Link)
+                                      />
+                                    </DummyIcon>
+                                  </styled.div>
+                                </a>
+                              </styled.a>
+                              <styled.a
                                 href="https://medium.com/styled-components"
                               >
-                                <Link
+                                <a
                                   className="c22"
                                   href="https://medium.com/styled-components"
-                                  unstyled={true}
                                 >
-                                  <Link
-                                    href="https://medium.com/styled-components"
+                                  <styled.div
+                                    as={[Function]}
+                                    height="18"
                                   >
-                                    <a
-                                      className="c22"
-                                      href="https://medium.com/styled-components"
+                                    <DummyIcon
+                                      className="c24"
+                                      height="18"
                                     >
-                                      <styled.div
-                                        as={[Function]}
+                                      <svg
+                                        className="c24"
                                         height="18"
-                                      >
-                                        <DummyIcon
-                                          className="c24"
-                                          height="18"
-                                        >
-                                          <svg
-                                            className="c24"
-                                            height="18"
-                                          />
-                                        </DummyIcon>
-                                      </styled.div>
-                                    </a>
-                                  </Link>
-                                </Link>
-                              </Styled(Link)>
+                                      />
+                                    </DummyIcon>
+                                  </styled.div>
+                                </a>
+                              </styled.a>
                             </nav>
                           </styled.nav>
                         </Social>

--- a/test/components/__snapshots__/DocsLayout.spec.js.snap
+++ b/test/components/__snapshots__/DocsLayout.spec.js.snap
@@ -973,113 +973,83 @@ exports[`DocsLayout renders correctly 1`] = `
                               <nav
                                 className="c22 c21 "
                               >
-                                <Styled(Link)
+                                <styled.a
                                   href="https://spectrum.chat/styled-components/"
                                 >
-                                  <Link
+                                  <a
                                     className="c23"
                                     href="https://spectrum.chat/styled-components/"
-                                    unstyled={true}
                                   >
-                                    <Link
-                                      href="https://spectrum.chat/styled-components/"
-                                    >
-                                      <a
-                                        className="c23"
-                                        href="https://spectrum.chat/styled-components/"
+                                    <Spectrum>
+                                      <styled.svg
+                                        height="14"
+                                        viewBox="0 0 15 15"
+                                        width="14"
                                       >
-                                        <Spectrum>
-                                          <styled.svg
-                                            height="14"
-                                            viewBox="0 0 15 15"
-                                            width="14"
-                                          >
-                                            <svg
-                                              className="c24"
-                                              height="14"
-                                              viewBox="0 0 15 15"
-                                              width="14"
-                                            >
-                                              <title>
-                                                spectrum
-                                              </title>
-                                              <path
-                                                d="M0 6.5V1c0-.6.4-1 1-1 9 .3 13.7 5 14 14 0 .6-.4 1-1 1H8.5c-.6 0-1-.4-1-1-.3-4.4-2-6.2-6.5-6.5-.6 0-1-.4-1-1z"
-                                                fill="#FFF"
-                                              />
-                                            </svg>
-                                          </styled.svg>
-                                        </Spectrum>
-                                      </a>
-                                    </Link>
-                                  </Link>
-                                </Styled(Link)>
-                                <Styled(Link)
+                                        <svg
+                                          className="c24"
+                                          height="14"
+                                          viewBox="0 0 15 15"
+                                          width="14"
+                                        >
+                                          <title>
+                                            spectrum
+                                          </title>
+                                          <path
+                                            d="M0 6.5V1c0-.6.4-1 1-1 9 .3 13.7 5 14 14 0 .6-.4 1-1 1H8.5c-.6 0-1-.4-1-1-.3-4.4-2-6.2-6.5-6.5-.6 0-1-.4-1-1z"
+                                            fill="#FFF"
+                                          />
+                                        </svg>
+                                      </styled.svg>
+                                    </Spectrum>
+                                  </a>
+                                </styled.a>
+                                <styled.a
                                   href="https://github.com/styled-components"
                                 >
-                                  <Link
+                                  <a
                                     className="c23"
                                     href="https://github.com/styled-components"
-                                    unstyled={true}
                                   >
-                                    <Link
-                                      href="https://github.com/styled-components"
+                                    <styled.div
+                                      as={[Function]}
+                                      height="18"
                                     >
-                                      <a
-                                        className="c23"
-                                        href="https://github.com/styled-components"
+                                      <DummyIcon
+                                        className="c25"
+                                        height="18"
                                       >
-                                        <styled.div
-                                          as={[Function]}
+                                        <svg
+                                          className="c25"
                                           height="18"
-                                        >
-                                          <DummyIcon
-                                            className="c25"
-                                            height="18"
-                                          >
-                                            <svg
-                                              className="c25"
-                                              height="18"
-                                            />
-                                          </DummyIcon>
-                                        </styled.div>
-                                      </a>
-                                    </Link>
-                                  </Link>
-                                </Styled(Link)>
-                                <Styled(Link)
+                                        />
+                                      </DummyIcon>
+                                    </styled.div>
+                                  </a>
+                                </styled.a>
+                                <styled.a
                                   href="https://medium.com/styled-components"
                                 >
-                                  <Link
+                                  <a
                                     className="c23"
                                     href="https://medium.com/styled-components"
-                                    unstyled={true}
                                   >
-                                    <Link
-                                      href="https://medium.com/styled-components"
+                                    <styled.div
+                                      as={[Function]}
+                                      height="18"
                                     >
-                                      <a
-                                        className="c23"
-                                        href="https://medium.com/styled-components"
+                                      <DummyIcon
+                                        className="c25"
+                                        height="18"
                                       >
-                                        <styled.div
-                                          as={[Function]}
+                                        <svg
+                                          className="c25"
                                           height="18"
-                                        >
-                                          <DummyIcon
-                                            className="c25"
-                                            height="18"
-                                          >
-                                            <svg
-                                              className="c25"
-                                              height="18"
-                                            />
-                                          </DummyIcon>
-                                        </styled.div>
-                                      </a>
-                                    </Link>
-                                  </Link>
-                                </Styled(Link)>
+                                        />
+                                      </DummyIcon>
+                                    </styled.div>
+                                  </a>
+                                </styled.a>
                               </nav>
                             </styled.nav>
                           </Social>
@@ -1335,113 +1305,83 @@ exports[`DocsLayout renders correctly 1`] = `
                                   <nav
                                     className="c22"
                                   >
-                                    <Styled(Link)
+                                    <styled.a
                                       href="https://spectrum.chat/styled-components/"
                                     >
-                                      <Link
+                                      <a
                                         className="c23"
                                         href="https://spectrum.chat/styled-components/"
-                                        unstyled={true}
                                       >
-                                        <Link
-                                          href="https://spectrum.chat/styled-components/"
-                                        >
-                                          <a
-                                            className="c23"
-                                            href="https://spectrum.chat/styled-components/"
+                                        <Spectrum>
+                                          <styled.svg
+                                            height="14"
+                                            viewBox="0 0 15 15"
+                                            width="14"
                                           >
-                                            <Spectrum>
-                                              <styled.svg
-                                                height="14"
-                                                viewBox="0 0 15 15"
-                                                width="14"
-                                              >
-                                                <svg
-                                                  className="c24"
-                                                  height="14"
-                                                  viewBox="0 0 15 15"
-                                                  width="14"
-                                                >
-                                                  <title>
-                                                    spectrum
-                                                  </title>
-                                                  <path
-                                                    d="M0 6.5V1c0-.6.4-1 1-1 9 .3 13.7 5 14 14 0 .6-.4 1-1 1H8.5c-.6 0-1-.4-1-1-.3-4.4-2-6.2-6.5-6.5-.6 0-1-.4-1-1z"
-                                                    fill="#FFF"
-                                                  />
-                                                </svg>
-                                              </styled.svg>
-                                            </Spectrum>
-                                          </a>
-                                        </Link>
-                                      </Link>
-                                    </Styled(Link)>
-                                    <Styled(Link)
+                                            <svg
+                                              className="c24"
+                                              height="14"
+                                              viewBox="0 0 15 15"
+                                              width="14"
+                                            >
+                                              <title>
+                                                spectrum
+                                              </title>
+                                              <path
+                                                d="M0 6.5V1c0-.6.4-1 1-1 9 .3 13.7 5 14 14 0 .6-.4 1-1 1H8.5c-.6 0-1-.4-1-1-.3-4.4-2-6.2-6.5-6.5-.6 0-1-.4-1-1z"
+                                                fill="#FFF"
+                                              />
+                                            </svg>
+                                          </styled.svg>
+                                        </Spectrum>
+                                      </a>
+                                    </styled.a>
+                                    <styled.a
                                       href="https://github.com/styled-components"
                                     >
-                                      <Link
+                                      <a
                                         className="c23"
                                         href="https://github.com/styled-components"
-                                        unstyled={true}
                                       >
-                                        <Link
-                                          href="https://github.com/styled-components"
+                                        <styled.div
+                                          as={[Function]}
+                                          height="18"
                                         >
-                                          <a
-                                            className="c23"
-                                            href="https://github.com/styled-components"
+                                          <DummyIcon
+                                            className="c25"
+                                            height="18"
                                           >
-                                            <styled.div
-                                              as={[Function]}
+                                            <svg
+                                              className="c25"
                                               height="18"
-                                            >
-                                              <DummyIcon
-                                                className="c25"
-                                                height="18"
-                                              >
-                                                <svg
-                                                  className="c25"
-                                                  height="18"
-                                                />
-                                              </DummyIcon>
-                                            </styled.div>
-                                          </a>
-                                        </Link>
-                                      </Link>
-                                    </Styled(Link)>
-                                    <Styled(Link)
+                                            />
+                                          </DummyIcon>
+                                        </styled.div>
+                                      </a>
+                                    </styled.a>
+                                    <styled.a
                                       href="https://medium.com/styled-components"
                                     >
-                                      <Link
+                                      <a
                                         className="c23"
                                         href="https://medium.com/styled-components"
-                                        unstyled={true}
                                       >
-                                        <Link
-                                          href="https://medium.com/styled-components"
+                                        <styled.div
+                                          as={[Function]}
+                                          height="18"
                                         >
-                                          <a
-                                            className="c23"
-                                            href="https://medium.com/styled-components"
+                                          <DummyIcon
+                                            className="c25"
+                                            height="18"
                                           >
-                                            <styled.div
-                                              as={[Function]}
+                                            <svg
+                                              className="c25"
                                               height="18"
-                                            >
-                                              <DummyIcon
-                                                className="c25"
-                                                height="18"
-                                              >
-                                                <svg
-                                                  className="c25"
-                                                  height="18"
-                                                />
-                                              </DummyIcon>
-                                            </styled.div>
-                                          </a>
-                                        </Link>
-                                      </Link>
-                                    </Styled(Link)>
+                                            />
+                                          </DummyIcon>
+                                        </styled.div>
+                                      </a>
+                                    </styled.a>
                                   </nav>
                                 </styled.nav>
                               </Social>


### PR DESCRIPTION
See https://github.com/vercel/next.js/pull/8231/files/97f86eec4c400af05114d9632bfdfce996f1e955 for details.