### PR TITLE
Rename ZEIT Now to Vercel

### DIFF
--- a/components/Footer/index.js
+++ b/components/Footer/index.js
@@ -43,8 +43,8 @@ const Footer = () => (
     <FooterContent hero>
       {' '}
       {'Hosted on '}
-      <FooterLink inline href="https://zeit.co">
-        ▲ ZEIT Now
+      <FooterLink inline href="https://vercel.com">
+        ▲ Vercel
       </FooterLink>
       <br />
       {'Made with '}

--- a/sections/advanced/server-side-rendering.md
+++ b/sections/advanced/server-side-rendering.md
@@ -73,10 +73,10 @@ If rendering fails for any reason it's a good idea to use `try...catch...finally
 ### Next.js
 
 Basically you need to add a custom `pages/_document.js` (if you don't have one). Then
-[copy the logic](https://github.com/zeit/next.js/tree/master/examples/with-styled-components/pages/_document.js)
+[copy the logic](https://github.com/vercel/next.js/tree/master/examples/with-styled-components/pages/_document.js)
 for styled-components to inject the server side rendered styles into the `<head>`.
 
-Refer to [our example](https://github.com/zeit/next.js/tree/master/examples/with-styled-components) in the Next.js repo for an up-to-date usage example.
+Refer to [our example](https://github.com/vercel/next.js/tree/master/examples/with-styled-components) in the Next.js repo for an up-to-date usage example.
 
 ### Gatsby
 


### PR DESCRIPTION
[ZEIT is now Vercel](https://vercel.com/blog/zeit-is-now-vercel) so we can update the footer:
![image](https://user-images.githubusercontent.com/6616955/89076418-89d60280-d380-11ea-9338-9a8238bacecc.png)

Also replaces `github.com/zeit/next.js` with `github.com/vercel/next.js` in two links.