### PR TITLE
Feature: remove brands animation on the website if 'prefers-reduced-motion' is on

### DIFF
--- a/components/UsersLogos/index.js
+++ b/components/UsersLogos/index.js
@@ -36,13 +36,17 @@ const UsersSlider = styled.span`
   ${UsersWrapper} {
     flex-direction: ${({ reverse }) => (reverse ? 'row' : 'row-reverse')};
   }
+
+  @media (prefers-reduced-motion) {
+    animation: none;
+  }
 `;
 
 const CompanyLogo = styled.span`
   position: relative;
-  height: ${p => p.height || '2rem'};
+  height: ${(p) => p.height || '2rem'};
   margin: 0 1rem;
-  bottom: ${p => p.bottom || 0};
+  bottom: ${(p) => p.bottom || 0};
   opacity: 0.8;
   filter: brightness(0) invert(1);
   transition: opacity 125ms ease-in-out;


### PR DESCRIPTION
## Description
Add the ability to disable the brands animations on the website if the user has set the device to reduce or remove animations system-wide.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion): _Readers with vestibular motion disorders may wish to enable the reduce motion feature on their device before viewing the animation._

## Issue
This PR fixes the issue [#3278](https://github.com/styled-components/styled-components/issues/3278) from the **styled-components** repository.

## Reproducing
The reduce motion can be enabled on macOS by going to **System Preferences > Accessibility > Display** and turning **Reduce motion** _on_.
