### PR TITLE
Fixes transform of IMDb's label on hover (Fix #738)

### DIFF
--- a/components/SmallShowcase/index.js
+++ b/components/SmallShowcase/index.js
@@ -76,23 +76,29 @@ const Website = styled.div`
 
     &:hover {
       transform: scale(${props => scaleFactor[Math.abs(props.position - 2)] + 0.2});
-
-      &:nth-of-type(-n + 2) {
+      &:nth-of-type(1) {
         ${Label} {
-          left: 0;
+          left:0;
           transform: translate(0, 50%);
         }
       }
-
-      &:nth-of-type(4),
-      &:nth-of-type(5) {
-        ${Label} {
-          right: 0;
-          transform: translate(0, 50%);
-        }
-      }
-    }
-  }
+ 
+      &:nth-of-type(2) {
+         ${Label} {
+          left:0;
+          transform: translate(-15%, 50%);
+         }
+       }
+      
+       &:nth-of-type(4),
+       &:nth-of-type(5) {
+         ${Label} {
+           right: 0;
+           transform: translate(0, 50%);
+         }
+       }
+     }
+   }
 `;
 
 const RatioBox = styled.div`


### PR DESCRIPTION
My proposal to update transform on hover. fix #738

```javascript
&:nth-of-type(1) {
    ${Label} {
      left:0;
      transform: translate(0, 50%);
    }
  }
  &:nth-of-type(2) {
    ${Label} {
      left:0;
      transform: translate(-15%, 50%);
    }
  }
  &:nth-of-type(4),
  &:nth-of-type(5) {
    ${Label} {
      right: 0;
      transform: translate(0, 50%);
    }
  }
```

![imdb4](https://user-images.githubusercontent.com/70724052/96803649-8bf6ad00-1415-11eb-9efc-16f7591d301e.png)
