### PR TITLE
docs: fix Snack example

### DIFF
--- a/sections/basics/react-native.md
+++ b/sections/basics/react-native.md
@@ -1,7 +1,7 @@
 ## React Native
 
 styled-components can be used with React Native in the same way and with the
-same import. Try this example with [Snack by Expo](https://snack.expo.io/@danielmschmidt/styled-components).
+same import. Try this example with [Snack by Expo](https://snack.expo.io/@danielmschmidt/styled-components?sdkVersion=latest&dependencies=styled-components/native,styled-components,react-is).
 
 ```jsx
 import React from 'react'


### PR DESCRIPTION
This PR fixes the react-native Snack example.

Fixes #440

![image](https://user-images.githubusercontent.com/6184593/96996839-dae53500-1530-11eb-8be7-4f3f9278afd2.png)

 The Snack itself is outdated and this PR updates the Snack link to always work with the latest Expo SDK and latest version `styled-components`. This makes maintenance much easier and doesn't require upgrading the Snack for every `styled-components` or Expo SDK update.

After the change all warnings are gone and the Snack renders correctly on both Native and Web.

![image](https://user-images.githubusercontent.com/6184593/96996981-28fa3880-1531-11eb-8366-1ff4ff4f3c67.png)

Test link: https://snack.expo.io/@danielmschmidt/styled-components?sdkVersion=latest&dependencies=styled-components/native,styled-components,react-is






