### PR TITLE
Add a note about using short-circuit evaluation to conditionally add CSS rules

### DIFF
--- a/sections/advanced/tagged-template-literals.md
+++ b/sections/advanced/tagged-template-literals.md
@@ -7,23 +7,36 @@ If you pass no interpolations, the first argument your function receives is an a
 
 ```jsx
 // These are equivalent:
-fn`some string here`
-fn(['some string here'])
+fn`some string here`;
+fn(['some string here']);
 ```
 
 Once you pass interpolations, the array contains the passed string, split at the positions of the interpolations.
 The rest of the arguments will be the interpolations, in order.
 
 ```jsx
-const aVar = 'good'
+const aVar = 'good';
 
 // These are equivalent:
-fn`this is a ${aVar} day`
-fn(['this is a ', ' day'], aVar)
+fn`this is a ${aVar} day`;
+fn(['this is a ', ' day'], aVar);
 ```
 
 This is a bit cumbersome to work with, but it means that we can receive variables, functions, or mixins
 (`css` helper) in styled components and can flatten that into pure CSS.
+
+Speaking of which, during flattening, styled-components ignores interpolations that evaluate to `undefined`, `null`,
+`false`, or an empty string (`""`), which means you're free to use
+[short-circuit evaluation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND#Short-circuit_evaluation)
+to conditionally add CSS rules.
+
+```jsx
+const Title = styled.h1`
+  /* Text centering won't break if props.upsidedown is falsy */
+  ${props.upsidedown && 'transform: rotate(180deg);'}
+  text-align: center;
+`;
+```
 
 If you want to learn more about tagged template literals, check out Max Stoiber's article:
 [The magic behind 💅🏾 styled-components](https://mxstbr.blog/2016/11/styled-components-magic-explained/)


### PR DESCRIPTION
I just discovered that in the process of flattening CSS, styled-components [ignores](https://github.com/styled-components/styled-components/blob/08390f25fa7e353107f0a30080075104cec6426f/packages/styled-components/src/utils/flatten.js#L13-L16) interpolations that evaluate to `undefined`, `null`, `false`, or an empty string. I think this fact may not be widely known, though, because in a certain [component library](https://github.com/Faithlife/styled-ui) I'm working on, I'm seeing a lot of `${props.condition ? 'rule-name: value;' : ''}` in styled components instead of `${props.condition && 'rule-name: value;'}`, seemingly out of a fear that `false` or `undefined` will stringify and break their CSS.

So I've written a short addition to the Tagged Template Literals section that lets people know that using short-circuit evaluation to add CSS rules is okay. Here's the new content:

> Speaking of which, during flattening, styled-components ignores interpolations that evaluate to `undefined`, `null`, `false`, or an empty string (`""`), which means you're free to use [short-circuit evaluation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND#Short-circuit_evaluation) to conditionally add CSS rules.
>
> ```jsx
> const Title = styled.h1`
>   /* Text centering won't break if props.upsidedown is falsy */
>   ${props.upsidedown && 'transform: rotate(180deg);'}
>   text-align: center;
> `;
> ```

How's that look? Is there a better place to put something like this?

And please pardon the adding of semicolons to the preexisting examples
on the page—that was the precommit linting that did that.