### PR TITLE
Use yarn instead of npm in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ git clone https://github.com/styled-components/styled-components-website
 # Enter the repo
 cd styled-components-website
 # Install the dependencies
-npm install
+yarn
 # Start local development
-npm run dev
+yarn dev
 ```
 
-> Note: This requires Node.js and npm to be set up locally, see [nodejs.org](https://nodejs.org) for more information.
+> Note: This requires Node.js and Yarn to be set up locally; see [nodejs.org](https://nodejs.org) and [yarnpkg.com](https://yarnpkg.com) for more information.
 
 ### Updating the visual diffs
 


### PR DESCRIPTION
So no one accidentally creates a `package-lock.json` (which would conflict with `yarn.lock`).