### PR TITLE
Update Next.js links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Thank you so much for wanting to contribute to the website! We could really use 
 
 If you've never worked with the technologies used in this repo, here are some links that may help:
 
-- [**Learn Next.js**](https://learnnextjs.com/)
-- [Next.js documentation](https://github.com/zeit/next.js)
+- [**Learn Next.js**](https://nextjs.org/learn)
+- [Next.js documentation](https://github.com/vercel/next.js)
 - [styled-components documentation](https://styled-components.com) (this very website!)
 
 ### Running locally


### PR DESCRIPTION
[learnnextjs.com](https://learnnextjs.com/) 404s now instead of redirecting.