### PR TITLE
Fix snapshot example

### DIFF
--- a/sections/tooling/jest.md
+++ b/sections/tooling/jest.md
@@ -35,7 +35,7 @@ And here's an example of the resulting snapshot:
 ```jsx
 exports[`it works 1`] = `
 .c0 {
-  color: green;
+  color: red;
 }
 
 <button


### PR DESCRIPTION
The snapshot example contained color: green; even though the example code contains color: red;