### PR TITLE
Fix syntax and formatting in styled-theming.md

### DIFF
--- a/sections/tooling/styled-theming.md
+++ b/sections/tooling/styled-theming.md
@@ -93,8 +93,8 @@ theme("whatever", {...});
 value provided to `<ThemeProvider>` theme.
 
 ```jsx
-<ThemeProvider theme={{ mode: "light" }}/>
-<ThemeProvider theme={{ mode: "dark" }}/>
+<ThemeProvider theme={{ mode: "light" }} />
+<ThemeProvider theme={{ mode: "dark" }} />
 
 theme("mode", {
   light: "...",
@@ -111,8 +111,8 @@ theme("mode", {
 });
 
 theme("font", {
-  sansSerif: ""Helvetica Neue", Helvetica, Arial, sans-serif",
-  serif: "Georgia, Times, "Times New Roman", serif",
+  sansSerif: '"Helvetica Neue", Helvetica, Arial, sans-serif',
+  serif: 'Georgia, Times, "Times New Roman", serif',
   monoSpaced: "Consolas, monaco, monospace",
 });
 ```
@@ -174,8 +174,8 @@ Button.defaultProps = {
   variant: "default",
 };
 
-<Button/>
-<Button variant="primary"/>
-<Button variant="success"/>
-<Button variant="warning"/>
+<Button />
+<Button variant="primary" />
+<Button variant="success" />
+<Button variant="warning" />
 ```


### PR DESCRIPTION
Fixed a couple of syntax errors in font-family strings, as well as a bit of formatting regarding self-closing JSX elements.