### PR TITLE
RSS Feed for Releases page

### DIFF
--- a/components/DocsLayout.js
+++ b/components/DocsLayout.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
+import styled from 'styled-components';
+import { RssFeed as RssFeedIcon } from '@styled-icons/material';
 import Head from './SeoHead';
+import Link from './Link';
 import Nav from './Nav';
 import { Container, Content, Title } from './Layout';
 
@@ -33,13 +36,14 @@ class DocsLayout extends Component {
   };
 
   render() {
-    const { children, title, description, useDocsSidebarMenu = true, pages } = this.props;
+    const { children, title, description, useDocsSidebarMenu = true, pages, rssFeedLink } = this.props;
     const { isSideFolded, isMobileNavFolded } = this.state;
 
     return (
       <Container>
         <Head title={`styled-components${title ? `: ${title}` : ''}`} description={description}>
           <meta name="robots" content="noodp" />
+          {rssFeedLink && <link rel="alternate" type="application/rss+xml" title="RSS Feed" href={rssFeedLink} />}
         </Head>
 
         <Nav
@@ -53,7 +57,14 @@ class DocsLayout extends Component {
         />
 
         <Content moveRight={!isSideFolded} data-e2e-id="content">
-          <Title>{title}</Title>
+          <TitleRow>
+            <Title>{title}</Title>
+            {rssFeedLink && (
+              <RssFeedLink inline target="__blank" href={rssFeedLink}>
+                <RssFeedIcon />
+              </RssFeedLink>
+            )}
+          </TitleRow>
 
           {children}
         </Content>
@@ -61,5 +72,20 @@ class DocsLayout extends Component {
     );
   }
 }
+
+const TitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  ${() => RssFeedLink} {
+    flex-shrink: 0;
+  }
+`;
+
+const RssFeedLink = styled(Link)`
+  width: 1.5em;
+`;
 
 export default DocsLayout;

--- a/components/DocsLayout.js
+++ b/components/DocsLayout.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
-import { RssFeed as RssFeedIcon } from '@styled-icons/material';
+import { RssFeed as FeedIcon } from '@styled-icons/material';
 import Head from './SeoHead';
 import Link from './Link';
 import Nav from './Nav';
@@ -36,14 +36,15 @@ class DocsLayout extends Component {
   };
 
   render() {
-    const { children, title, description, useDocsSidebarMenu = true, pages, rssFeedLink } = this.props;
+    const { children, title, description, useDocsSidebarMenu = true, pages, feedLink } = this.props;
     const { isSideFolded, isMobileNavFolded } = this.state;
+    const prefixedTitle = `styled-components${title ? `: ${title}` : ''}`;
 
     return (
       <Container>
-        <Head title={`styled-components${title ? `: ${title}` : ''}`} description={description}>
+        <Head title={prefixedTitle} description={description}>
           <meta name="robots" content="noodp" />
-          {rssFeedLink && <link rel="alternate" type="application/rss+xml" title="RSS Feed" href={rssFeedLink} />}
+          {feedLink && <link rel="alternate" type="application/atom+xml" title={prefixedTitle} href={feedLink} />}
         </Head>
 
         <Nav
@@ -59,10 +60,10 @@ class DocsLayout extends Component {
         <Content moveRight={!isSideFolded} data-e2e-id="content">
           <TitleRow>
             <Title>{title}</Title>
-            {rssFeedLink && (
-              <RssFeedLink inline target="__blank" href={rssFeedLink}>
-                <RssFeedIcon />
-              </RssFeedLink>
+            {feedLink && (
+              <FeedLink inline target="__blank" href={feedLink}>
+                <FeedIcon />
+              </FeedLink>
             )}
           </TitleRow>
 
@@ -79,12 +80,12 @@ const TitleRow = styled.div`
   justify-content: space-between;
   gap: 1rem;
 
-  ${() => RssFeedLink} {
+  ${() => FeedLink} {
     flex-shrink: 0;
   }
 `;
 
-const RssFeedLink = styled(Link)`
+const FeedLink = styled(Link)`
   width: 1.5em;
 `;
 

--- a/pages/releases.js
+++ b/pages/releases.js
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 import DocsLayout from '../components/DocsLayout';
 import components from '../utils/mdx-components';
-import { getReleases } from '../utils/githubApi';
+import { getReleases, getReleasesAtomFeedURI } from '../utils/githubApi';
 import Anchor from '../components/Anchor';
 import Loading from '../components/Loading';
 import rem from '../utils/rem';
@@ -21,7 +21,13 @@ const ReleaseAnchor = styled(Anchor)`
 `;
 
 const Releases = ({ releases, sidebarPages }) => (
-  <DocsLayout useDocsSidebarMenu={false} pages={sidebarPages} title="Releases" description="Styled Components Releases">
+  <DocsLayout
+    useDocsSidebarMenu={false}
+    pages={sidebarPages}
+    title="Releases"
+    description="Styled Components Releases"
+    rssFeedLink={getReleasesAtomFeedURI()}
+  >
     <Markdown>
       Updating styled components is usually as simple as `npm install`. Only major versions have the potential to
       introduce breaking changes (noted in the following release notes).

--- a/pages/releases.js
+++ b/pages/releases.js
@@ -26,7 +26,7 @@ const Releases = ({ releases, sidebarPages }) => (
     pages={sidebarPages}
     title="Releases"
     description="Styled Components Releases"
-    rssFeedLink={getReleasesAtomFeedURI()}
+    feedLink={getReleasesAtomFeedURI()}
   >
     <Markdown>
       Updating styled components is usually as simple as `npm install`. Only major versions have the potential to

--- a/utils/githubApi.js
+++ b/utils/githubApi.js
@@ -3,5 +3,10 @@ import 'isomorphic-fetch';
 export const getReadme = (repo = 'styled-components') =>
   fetch(`https://cdn.rawgit.com/styled-components/${repo}/master/README.md`).then((resp) => resp.text());
 
-export const getReleases = (repo = 'styled-components') =>
-  fetch(`https://api.github.com/repos/styled-components/${repo}/releases`).then((resp) => resp.json());
+export const getReleasesURI = (repo = 'styled-components') =>
+  `https://api.github.com/repos/styled-components/${repo}/releases`;
+
+export const getReleasesAtomFeedURI = (repo = 'styled-components') =>
+  `https://github.com/styled-components/${repo}/releases.atom`;
+
+export const getReleases = (repo = 'styled-components') => fetch(getReleasesURI(repo)).then((resp) => resp.json());


### PR DESCRIPTION
### What/Why
* Added support to the `DocsLayout` component for an RSS icon link that appears next to the header and adds <head> tags for feed discovery with servies like Feedly.
* Added getters for github release page atom feed URIs
* Added an RSS feed link to the `/releases` page

### Issue
Closes #598 

### Screenshot
![image](https://user-images.githubusercontent.com/90214887/132259297-9dff656f-2486-4c51-93f2-d6d0b515ae4b.png)
