### PR TITLE
Add back max-width:100% to Layout__Content styled component to fix broken mobile docs layout

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -14,6 +14,7 @@ export const Container = styled.div`
 `;
 
 export const Content = styled.div`
+  max-width: 100%;
   margin: 0;
   padding: ${rem(90)} ${rem(60)} 0 ${rem(60)};
   box-sizing: border-box;

--- a/test/components/__snapshots__/DocsLayout.spec.js.snap
+++ b/test/components/__snapshots__/DocsLayout.spec.js.snap
@@ -473,6 +473,7 @@ exports[`DocsLayout renders correctly 1`] = `
 }
 
 .c37 {
+  max-width: 100%;
   margin: 0;
   padding: 5rem 3.3333333333333335rem 0 3.3333333333333335rem;
   box-sizing: border-box;

--- a/test/components/__snapshots__/Layout.spec.js.snap
+++ b/test/components/__snapshots__/Layout.spec.js.snap
@@ -18,6 +18,7 @@ exports[`Container renders correctly 1`] = `
 
 exports[`Content renders correctly 1`] = `
 .c0 {
+  max-width: 100%;
   margin: 0;
   padding: 5rem 3.3333333333333335rem 0 3.3333333333333335rem;
   box-sizing: border-box;


### PR DESCRIPTION
### Bugfix: Add back max-width:100% to Layout__Content styled component to fix broken mobile docs layout

Currently, the layout on mobile is able to be overflowed quite a lot (see below). I found a change from PR #743 that seemed to be related to the layout breaking. 

![image](https://user-images.githubusercontent.com/25354920/148691963-375b5ebe-d6f8-4a45-976d-e0b8544ee10d.png)

Just a small change,

Hope this helps!

Kyle