### PR TITLE
yarn list - filtering by arguments is deprecated

### DIFF
--- a/sections/faqs/duplicated-styled-components.md
+++ b/sections/faqs/duplicated-styled-components.md
@@ -46,7 +46,7 @@ that will contain the `styled-components` module:
 
 ### Duplicated module in `node_modules`
 
-If you think that the issue is in duplicated `styled-components` module somewhere in your dependencies, there are several ways to check this. You can use `npm ls styled-components`, `yarn list styled-components` or `find -L ./node_modules | grep /styled-components/package.json` commands in your application folder.
+If you think that the issue is in duplicated `styled-components` module somewhere in your dependencies, there are several ways to check this. You can use `npm ls styled-components`, `yarn list --pattern styled-components` or `find -L ./node_modules | grep /styled-components/package.json` commands in your application folder.
 
 If none of these commands identified the duplication, try analyzing your bundle for multiple instances of `styled-components`. You can just check your bundle source, or use a tool like [source-map-explorer](https://github.com/danvk/source-map-explorer)
 or [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer).


### PR DESCRIPTION
Update documentation to remove deprecated command:

> Filtering by arguments is deprecated. Please use the pattern option instead.

[styled-components docs](https://styled-components.com/docs/faqs#duplicated-module-in-node_modules)
[yarn docs](https://classic.yarnpkg.com/lang/en/docs/cli/list/#toc-yarn-list-depth-pattern)