### PR TITLE
fix: Added fallback for Avenir next, addressed text wrapping issue and added support for windows file paths in lint-staged

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,10 @@
 module.exports = {
   '**/*.js?(x)': [
     'jest -c .jest.config.js --findRelatedTests',
-    (filenames) => `next lint --fix --file ${filenames.map((file) => file.split(process.cwd())[1]).join(' --file ')}`,
+    (filenames) =>
+      `next lint --fix --file ${filenames
+        .map((file) => file.split(process.cwd().replace(/\\/g, '/'))[1])
+        .join(' --file ')}`, // normalized path for windows
     'prettier --write',
   ],
   '*.md': ['prettier --write'],

--- a/components/SmallShowcase/index.js
+++ b/components/SmallShowcase/index.js
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import React from 'react';
 import styled from 'styled-components';
+import { headerFont } from '../../utils/fonts';
 
 const scaleFactor = [1.8, 1.4, 1];
 
@@ -39,7 +40,7 @@ const Label = styled.label`
   transform: translate(-50%, 50%);
   background-color: white;
   color: #333;
-  font-family: Avenir Next;
+  font-family: ${headerFont};
   font-weight: bold;
   font-size: 0.8rem;
   padding: 2px 12px;

--- a/components/SmallShowcase/index.js
+++ b/components/SmallShowcase/index.js
@@ -41,9 +41,8 @@ const Label = styled.label`
   background-color: white;
   color: #333;
   font-family: ${headerFont};
-  font-weight: bold;
-  font-size: 0.8rem;
   padding: 2px 12px;
+  white-space: nowrap;
   border-radius: 6px;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08), 0 5px 12px rgba(0, 0, 0, 0.1);
   opacity: 0;

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,6 +16,7 @@ import Nav from '../components/Nav';
 import { sortedCompanies, sortedProjects } from '../companies-manifest';
 import UsersLogos from '../components/UsersLogos';
 import SmallShowcase from '../components/SmallShowcase';
+import { headerFont } from '../utils/fonts';
 
 const Tagline = styled.h1`
   font-weight: 600;
@@ -140,7 +141,7 @@ const ShowcaseLink = styled(NextLink)`
   line-height: 48px;
   text-align: center;
   color: white;
-  font-family: Avenir Next;
+  font-family: ${headerFont};
   border-radius: 4px;
   margin: 0 auto;
   background-color: ${blmGrey};

--- a/pages/showcase.js
+++ b/pages/showcase.js
@@ -139,7 +139,7 @@ const HeaderDecoration = styled.div`
   position: absolute;
   bottom: 0;
   left: 0;
-  font-family: Avenir Next;
+  font-family: ${headerFont};
   font-size: 16rem;
   line-height: 16rem;
   font-weight: 800;
@@ -186,7 +186,7 @@ const HeaderActions = styled.div`
   ${NativeSelect} {
     height: 50px;
     border-radius: 4px;
-    font-family: Avenir Next;
+    font-family: ${headerFont};
     font-weight: 500;
     font-size: 1rem;
     line-height: 50px;


### PR DESCRIPTION
# Fixed 3 problems:

* ##  Modified lint-staged to support windows file paths 
> Replaced `process.cwd()` with `process.cwd().replace(/\\/g, '/')`

* ## Added fallbacks for Avenir Next wherever applicable 
> For systems that do not have it already installed, it fallbacks to a serif font by default.
### Before
![image](https://user-images.githubusercontent.com/26746725/154871573-203caa48-b3cc-4dd6-a0bc-9fc5e0ce570a.png)
![image](https://user-images.githubusercontent.com/26746725/154871317-46583a8e-feca-416d-982e-e52523a3b84a.png)
### After
![image](https://user-images.githubusercontent.com/26746725/154871547-bb4eda83-6d7e-4f53-a070-018ca3566e43.png)
![image](https://user-images.githubusercontent.com/26746725/154871479-e97073a9-c863-4ccf-a376-fe5acccaeb73.png)

*  ## Fixed text being wrapped to next line during label animation
### Before

https://user-images.githubusercontent.com/26746725/154871674-bddbf952-f4b1-4b91-9085-5eb41c7409ce.mp4

### After

https://user-images.githubusercontent.com/26746725/154871704-382256e0-71ab-4aea-878f-cbcab380d9d8.mp4

Feel free to suggest changes! 😄
