### PR TITLE
feat: update nextjs integration docs and examples

### DIFF
--- a/sections/advanced/server-side-rendering.md
+++ b/sections/advanced/server-side-rendering.md
@@ -21,18 +21,18 @@ If possible, we definitely recommend using the babel plugin though because it is
 The basic API goes as follows:
 
 ```jsx
-import { renderToString } from 'react-dom/server'
-import { ServerStyleSheet } from 'styled-components'
+import { renderToString } from 'react-dom/server';
+import { ServerStyleSheet } from 'styled-components';
 
-const sheet = new ServerStyleSheet()
+const sheet = new ServerStyleSheet();
 try {
-  const html = renderToString(sheet.collectStyles(<YourApp />))
-  const styleTags = sheet.getStyleTags() // or sheet.getStyleElement();
+  const html = renderToString(sheet.collectStyles(<YourApp />));
+  const styleTags = sheet.getStyleTags(); // or sheet.getStyleElement();
 } catch (error) {
   // handle error
-  console.error(error)
+  console.error(error);
 } finally {
-  sheet.seal()
+  sheet.seal();
 }
 ```
 
@@ -41,22 +41,22 @@ the `StyleSheetManager` provider directly, instead of this method. Just make sur
 use it on the client-side.
 
 ```jsx
-import { renderToString } from 'react-dom/server'
-import { ServerStyleSheet, StyleSheetManager } from 'styled-components'
+import { renderToString } from 'react-dom/server';
+import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
 
-const sheet = new ServerStyleSheet()
+const sheet = new ServerStyleSheet();
 try {
   const html = renderToString(
     <StyleSheetManager sheet={sheet.instance}>
       <YourApp />
     </StyleSheetManager>
-  )
-  const styleTags = sheet.getStyleTags() // or sheet.getStyleElement();
+  );
+  const styleTags = sheet.getStyleTags(); // or sheet.getStyleElement();
 } catch (error) {
   // handle error
-  console.error(error)
+  console.error(error);
 } finally {
-  sheet.seal()
+  sheet.seal();
 }
 ```
 
@@ -72,11 +72,17 @@ If rendering fails for any reason it's a good idea to use `try...catch...finally
 
 ### Next.js
 
-Basically you need to add a custom `pages/_document.js` (if you don't have one). Then
-[copy the logic](https://github.com/vercel/next.js/tree/master/examples/with-styled-components/pages/_document.js)
-for styled-components to inject the server side rendered styles into the `<head>`.
+#### With Babel
 
-Refer to [our example](https://github.com/vercel/next.js/tree/master/examples/with-styled-components) in the Next.js repo for an up-to-date usage example.
+Basically you need to add a custom `pages/_document.js` (if you don't have one). Then [copy the logic](https://github.com/vercel/next.js/blob/canary/examples/with-styled-components-babel/pages/_document.js) for styled-components to inject the server side rendered styles into the `<head>`.
+
+Refer to [our example](https://github.com/vercel/next.js/tree/canary/examples/with-styled-components-babel) in the Next.js repo for an up-to-date usage example.
+
+#### With SWC
+
+[Since version 12](https://nextjs.org/blog/next-12), Next.js uses a Rust compiler called SWC. If you're not using any babel plugin, you should refer to [this example](https://github.com/vercel/next.js/tree/canary/examples/with-styled-components) instead.
+
+On this version, you [only need to add](https://github.com/vercel/next.js/blob/canary/examples/with-styled-components/next.config.js) `styledComponents: true,` at the compiler options in the `next.config.js` file.
 
 ### Gatsby
 
@@ -93,38 +99,35 @@ _On the server:_
 `ReactDOMServer.renderToNodeStream` emits a "readable" stream that styled-components wraps. As whole chunks of HTML are pushed onto the stream, if any corresponding styles are ready to be rendered, a style block is prepended to React's HTML and forwarded on to the client browser.
 
 ```js
-import { renderToNodeStream } from 'react-dom/server'
-import styled, { ServerStyleSheet } from 'styled-components'
+import { renderToNodeStream } from 'react-dom/server';
+import styled, { ServerStyleSheet } from 'styled-components';
 
 // if you're using express.js, you'd have access to the response object "res"
 
 // typically you'd want to write some preliminary HTML, since React doesn't handle this
-res.write('<html><head><title>Test</title></head><body>')
+res.write('<html><head><title>Test</title></head><body>');
 
 const Heading = styled.h1`
   color: red;
-`
+`;
 
-const sheet = new ServerStyleSheet()
-const jsx = sheet.collectStyles(<Heading>Hello SSR!</Heading>)
-const stream = sheet.interleaveWithNodeStream(renderToNodeStream(jsx))
+const sheet = new ServerStyleSheet();
+const jsx = sheet.collectStyles(<Heading>Hello SSR!</Heading>);
+const stream = sheet.interleaveWithNodeStream(renderToNodeStream(jsx));
 
 // you'd then pipe the stream into the response object until it's done
-stream.pipe(
-  res,
-  { end: false }
-)
+stream.pipe(res, { end: false });
 
 // and finalize the response with closing HTML
-stream.on('end', () => res.end('</body></html>'))
+stream.on('end', () => res.end('</body></html>'));
 ```
 
 _On the client:_
 
 ```js
-import { hydrate } from 'react-dom'
+import { hydrate } from 'react-dom';
 
-hydrate()
+hydrate();
 // your client-side react implementation
 ```
 


### PR DESCRIPTION
Hi!
With the new Next.js update, we don't need babel with a custom document for the styles to work, so I've updated the examples references.

English is not my first language, so feedback is also appreciated. Thanks!