### PR TITLE
update react-runner to v1.0

### DIFF
--- a/components/CodeBlock.js
+++ b/components/CodeBlock.js
@@ -10,7 +10,7 @@ const CodeBlock = styled(({ code, ...rest }) => {
   const language = (rest.language || 'clike').toLowerCase().trim();
 
   return (
-    <Code {...rest} disabled language={language}>
+    <Code {...rest} language={language}>
       {code}
     </Code>
   );

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",
-    "react-live-runner": "^1.0.0-rc.2",
+    "react-live-runner": "^1.0.0",
     "react-transition-group": "^4.4.2",
     "styled-components": "^5.3.3",
     "styled-theming": "^2.2.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -47,6 +47,10 @@ const Button = styled.a\`
     color: black;
   \`}
 \`
+`.trim();
+
+const transformHeaderCode = (code) => `
+${code}
 
 render(
   <div>
@@ -64,7 +68,7 @@ render(
     </Button>
   </div>
 )
-`.trim();
+`;
 
 const Title = styled.div`
   margin: 2rem 0;
@@ -191,7 +195,7 @@ class Index extends PureComponent {
 
         <Wrapper>
           <Content hero>
-            <LiveProvider code={headerCode} scope={{ styled: baseScope.styled, css, rem, Link }}>
+            <LiveProvider code={headerCode} transformCode={transformHeaderCode} scope={{ ...baseScope, rem, Link }}>
               <Logo />
 
               <Title>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6509,19 +6509,19 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-live-runner@^1.0.0-rc.2:
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/react-live-runner/-/react-live-runner-1.0.0-rc.2.tgz#68fcab1738110e4aca34dadcac633b7708447bf5"
-  integrity sha512-R0kIdKU0pmtXrk9E6a2yAOJ7Pj7dqh/jDGdNcu/pmrxt5ig8GWOZ2s4sFGnD1hVl7uB4Sci47eKcqhBnEqcmVw==
+react-live-runner@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-live-runner/-/react-live-runner-1.0.0.tgz#f38ea23b81f73e1e7f8fc7c397558b82986575c9"
+  integrity sha512-ZeZ/huaDWQqpazBwOeGwc7FwDuyzTDuVohmF2Y4MO2Z7aucs/AmP68vH9/qyF/gfv12DpNJFrV+pylvKbwvEhA==
   dependencies:
     prism-react-renderer "^1.2.1"
-    react-runner "^1.0.0-rc.2"
+    react-runner "^1.0.0"
     react-simple-code-editor "^0.11.0"
 
-react-runner@^1.0.0-rc.2:
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/react-runner/-/react-runner-1.0.0-rc.2.tgz#3591d3893a6262af345154292627e76612968850"
-  integrity sha512-caUnpbSawzX1cF7f38tmM9+CMDNZNUypIeYPROWKW5UALmo28pfHrad7XL2HRbTku76hiGE60Kxp6CWItW1jRg==
+react-runner@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-runner/-/react-runner-1.0.0.tgz#297a4e0e6a784c1befc874cd88e3e9b3d5d40444"
+  integrity sha512-rkcWe7MZpUxsqQ6m7NzwPi99hd/CQYXgw/VEdyUDyuhdaLoskVg02tbG6+DDrIvL5HquVIJjnxlARM0fE+3Oyg==
   dependencies:
     sucrase "^3.10.1"
 


### PR DESCRIPTION
There is no change since `rc.2`, but I changed the example in home page, so we can only edit the style, previously if we remove some code, the render part will be shown, which I think is not intended, as I can see if we don't edit the code, the render part is not editable, so I changed to simply hide it from editing, correct me if I'm wrong on that