### PR TITLE
docs: Add new react native declarations file

### DIFF
--- a/sections/api/typescript.md
+++ b/sections/api/typescript.md
@@ -43,6 +43,21 @@ declare module 'styled-components' {
 }
 ```
 
+React-Native:
+
+```ts
+declare module 'styled-components/native' {
+  export interface DefaultTheme {
+    borderRadius: string;
+
+    colors: {
+      main: string;
+      secondary: string;
+    };
+  }
+}
+```
+
 `DefaultTheme` is being used as an interface of `props.theme` out of the box. By default the interface `DefaultTheme` is empty so that's why we need to extend it.
 
 ### Create a theme


### PR DESCRIPTION
I've got stuck trying to type my theme props passed by ThemeProvider, then I found myself i've extending DefaultTheme from styled-components module, not for styled-components/native one. I think this little change can speed up other developers to setup the provider.