### PR TITLE
Update outdated LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Glen Maddern and Maximilian Stoiber
+Copyright (c) 2017 - present Glen Maddern and Maximilian Stoiber
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the outdated copyright year to the present.  So there will not be a need for any further license year updates