### PR TITLE
Add target _blank on external links for improve user experience

### DIFF
--- a/components/BlmBanner.js
+++ b/components/BlmBanner.js
@@ -17,7 +17,7 @@ const Banner = styled.a`
 
 export const BlmBanner = () => {
   return (
-    <Banner href="https://support.eji.org/give/153413/#!/donation/checkout">
+    <Banner href="https://support.eji.org/give/153413/#!/donation/checkout" target="_blank">
       #BlackLivesMatter ✊🏿 <span style={{ textDecoration: `underline` }}>Support the Equal Justice Initiative</span>
     </Banner>
   );

--- a/components/Link.js
+++ b/components/Link.js
@@ -33,7 +33,7 @@ export const InlineLink = styled.a.attrs((/* props */) => ({
   }
 `;
 
-const Link = ({ ['aria-label']: ariaLabel, children, className, inline, unstyled, white, ...rest }) => {
+const Link = ({ ['aria-label']: ariaLabel, children, className, inline, unstyled, white, isExternal, ...rest }) => {
   let Child = StyledLink;
   if (inline) {
     Child = InlineLink;
@@ -46,9 +46,14 @@ const Link = ({ ['aria-label']: ariaLabel, children, className, inline, unstyled
     dataAttrs = { 'data-white': white };
   }
 
+  let target;
+  if (isExternal) {
+    target = '_blank';
+  }
+
   return (
     <UnstyledLink {...rest}>
-      <Child aria-label={ariaLabel} href={rest.href} className={className} {...dataAttrs}>
+      <Child aria-label={ariaLabel} href={rest.href} className={className} {...dataAttrs} target={target}>
         {children}
       </Child>
     </UnstyledLink>

--- a/components/Nav/Social.js
+++ b/components/Nav/Social.js
@@ -78,12 +78,11 @@ const Social = (props) => (
     <SocialLink href="https://spectrum.chat/styled-components/" isExternal>
       <Spectrum />
     </SocialLink>
-    {/* <SocialLink href="https://twitter.com/someone">
-      <Twitter />
-    </SocialLink> */}
+
     <SocialLink href="https://github.com/styled-components" isExternal>
       <StyledIcon as={Github} height="18" />
     </SocialLink>
+
     <SocialLink href="https://medium.com/styled-components" isExternal>
       <StyledIcon as={MediumM} height="18" />
     </SocialLink>

--- a/components/Nav/Social.js
+++ b/components/Nav/Social.js
@@ -42,14 +42,14 @@ const SocialLink = styled(Link).attrs((/* props */) => ({
 `;
 
 const Svg = styled.svg`
-  width: ${p => rem(Number(p.width))};
-  height: ${p => rem(Number(p.height))};
+  width: ${(p) => rem(Number(p.width))};
+  height: ${(p) => rem(Number(p.height))};
 `;
 
 const StyledIcon = styled.div`
   && {
-    width: ${p => rem(Number(p.width))};
-    height: ${p => rem(Number(p.height))};
+    width: ${(p) => rem(Number(p.width))};
+    height: ${(p) => rem(Number(p.height))};
   }
 `;
 
@@ -73,18 +73,18 @@ const Spectrum = () => (
   </Svg>
 );
 
-const Social = props => (
+const Social = (props) => (
   <Wrapper {...props}>
-    <SocialLink href="https://spectrum.chat/styled-components/">
+    <SocialLink href="https://spectrum.chat/styled-components/" isExternal>
       <Spectrum />
     </SocialLink>
     {/* <SocialLink href="https://twitter.com/someone">
       <Twitter />
     </SocialLink> */}
-    <SocialLink href="https://github.com/styled-components">
+    <SocialLink href="https://github.com/styled-components" isExternal>
       <StyledIcon as={Github} height="18" />
     </SocialLink>
-    <SocialLink href="https://medium.com/styled-components">
+    <SocialLink href="https://medium.com/styled-components" isExternal>
       <StyledIcon as={MediumM} height="18" />
     </SocialLink>
   </Wrapper>

--- a/test/components/NavBar/__snapshots__/MobileNavbar.spec.js.snap
+++ b/test/components/NavBar/__snapshots__/MobileNavbar.spec.js.snap
@@ -368,6 +368,7 @@ exports[`MobileNavbar renders correctly 1`] = `
         <a
           className="c16"
           href="https://spectrum.chat/styled-components/"
+          target="_blank"
         >
           <svg
             className="c17"
@@ -387,6 +388,7 @@ exports[`MobileNavbar renders correctly 1`] = `
         <a
           className="c16"
           href="https://github.com/styled-components"
+          target="_blank"
         >
           <svg
             className="c18"
@@ -396,6 +398,7 @@ exports[`MobileNavbar renders correctly 1`] = `
         <a
           className="c16"
           href="https://medium.com/styled-components"
+          target="_blank"
         >
           <svg
             className="c18"

--- a/test/components/NavBar/__snapshots__/Navbar.spec.js.snap
+++ b/test/components/NavBar/__snapshots__/Navbar.spec.js.snap
@@ -672,6 +672,7 @@ exports[`Navbar renders correctly 1`] = `
         <a
           className="c17"
           href="https://spectrum.chat/styled-components/"
+          target="_blank"
         >
           <svg
             className="c18"
@@ -691,6 +692,7 @@ exports[`Navbar renders correctly 1`] = `
         <a
           className="c17"
           href="https://github.com/styled-components"
+          target="_blank"
         >
           <svg
             className="c19"
@@ -700,6 +702,7 @@ exports[`Navbar renders correctly 1`] = `
         <a
           className="c17"
           href="https://medium.com/styled-components"
+          target="_blank"
         >
           <svg
             className="c19"
@@ -819,6 +822,7 @@ exports[`Navbar renders correctly 1`] = `
           <a
             className="c17"
             href="https://spectrum.chat/styled-components/"
+            target="_blank"
           >
             <svg
               className="c18"
@@ -838,6 +842,7 @@ exports[`Navbar renders correctly 1`] = `
           <a
             className="c17"
             href="https://github.com/styled-components"
+            target="_blank"
           >
             <svg
               className="c19"
@@ -847,6 +852,7 @@ exports[`Navbar renders correctly 1`] = `
           <a
             className="c17"
             href="https://medium.com/styled-components"
+            target="_blank"
           >
             <svg
               className="c19"

--- a/test/components/NavBar/__snapshots__/index.spec.js.snap
+++ b/test/components/NavBar/__snapshots__/index.spec.js.snap
@@ -874,10 +874,12 @@ exports[`Nav renders correctly 1`] = `
                         >
                           <Social__SocialLink
                             href="https://spectrum.chat/styled-components/"
+                            isExternal={true}
                           >
                             <Link
                               className="c17"
                               href="https://spectrum.chat/styled-components/"
+                              isExternal={true}
                               unstyled={true}
                             >
                               <Link
@@ -886,6 +888,7 @@ exports[`Nav renders correctly 1`] = `
                                 <a
                                   className="c17"
                                   href="https://spectrum.chat/styled-components/"
+                                  target="_blank"
                                 >
                                   <Spectrum>
                                     <Social__Svg
@@ -915,10 +918,12 @@ exports[`Nav renders correctly 1`] = `
                           </Social__SocialLink>
                           <Social__SocialLink
                             href="https://github.com/styled-components"
+                            isExternal={true}
                           >
                             <Link
                               className="c17"
                               href="https://github.com/styled-components"
+                              isExternal={true}
                               unstyled={true}
                             >
                               <Link
@@ -927,6 +932,7 @@ exports[`Nav renders correctly 1`] = `
                                 <a
                                   className="c17"
                                   href="https://github.com/styled-components"
+                                  target="_blank"
                                 >
                                   <Social__StyledIcon
                                     as={[Function]}
@@ -948,10 +954,12 @@ exports[`Nav renders correctly 1`] = `
                           </Social__SocialLink>
                           <Social__SocialLink
                             href="https://medium.com/styled-components"
+                            isExternal={true}
                           >
                             <Link
                               className="c17"
                               href="https://medium.com/styled-components"
+                              isExternal={true}
                               unstyled={true}
                             >
                               <Link
@@ -960,6 +968,7 @@ exports[`Nav renders correctly 1`] = `
                                 <a
                                   className="c17"
                                   href="https://medium.com/styled-components"
+                                  target="_blank"
                                 >
                                   <Social__StyledIcon
                                     as={[Function]}
@@ -1228,10 +1237,12 @@ exports[`Nav renders correctly 1`] = `
                             >
                               <Social__SocialLink
                                 href="https://spectrum.chat/styled-components/"
+                                isExternal={true}
                               >
                                 <Link
                                   className="c17"
                                   href="https://spectrum.chat/styled-components/"
+                                  isExternal={true}
                                   unstyled={true}
                                 >
                                   <Link
@@ -1240,6 +1251,7 @@ exports[`Nav renders correctly 1`] = `
                                     <a
                                       className="c17"
                                       href="https://spectrum.chat/styled-components/"
+                                      target="_blank"
                                     >
                                       <Spectrum>
                                         <Social__Svg
@@ -1269,10 +1281,12 @@ exports[`Nav renders correctly 1`] = `
                               </Social__SocialLink>
                               <Social__SocialLink
                                 href="https://github.com/styled-components"
+                                isExternal={true}
                               >
                                 <Link
                                   className="c17"
                                   href="https://github.com/styled-components"
+                                  isExternal={true}
                                   unstyled={true}
                                 >
                                   <Link
@@ -1281,6 +1295,7 @@ exports[`Nav renders correctly 1`] = `
                                     <a
                                       className="c17"
                                       href="https://github.com/styled-components"
+                                      target="_blank"
                                     >
                                       <Social__StyledIcon
                                         as={[Function]}
@@ -1302,10 +1317,12 @@ exports[`Nav renders correctly 1`] = `
                               </Social__SocialLink>
                               <Social__SocialLink
                                 href="https://medium.com/styled-components"
+                                isExternal={true}
                               >
                                 <Link
                                   className="c17"
                                   href="https://medium.com/styled-components"
+                                  isExternal={true}
                                   unstyled={true}
                                 >
                                   <Link
@@ -1314,6 +1331,7 @@ exports[`Nav renders correctly 1`] = `
                                     <a
                                       className="c17"
                                       href="https://medium.com/styled-components"
+                                      target="_blank"
                                     >
                                       <Social__StyledIcon
                                         as={[Function]}

--- a/test/components/__snapshots__/DocsLayout.spec.js.snap
+++ b/test/components/__snapshots__/DocsLayout.spec.js.snap
@@ -929,10 +929,12 @@ exports[`DocsLayout renders correctly 1`] = `
                               >
                                 <Social__SocialLink
                                   href="https://spectrum.chat/styled-components/"
+                                  isExternal={true}
                                 >
                                   <Link
                                     className="c18"
                                     href="https://spectrum.chat/styled-components/"
+                                    isExternal={true}
                                     unstyled={true}
                                   >
                                     <Link
@@ -941,6 +943,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                       <a
                                         className="c18"
                                         href="https://spectrum.chat/styled-components/"
+                                        target="_blank"
                                       >
                                         <Spectrum>
                                           <Social__Svg
@@ -970,10 +973,12 @@ exports[`DocsLayout renders correctly 1`] = `
                                 </Social__SocialLink>
                                 <Social__SocialLink
                                   href="https://github.com/styled-components"
+                                  isExternal={true}
                                 >
                                   <Link
                                     className="c18"
                                     href="https://github.com/styled-components"
+                                    isExternal={true}
                                     unstyled={true}
                                   >
                                     <Link
@@ -982,6 +987,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                       <a
                                         className="c18"
                                         href="https://github.com/styled-components"
+                                        target="_blank"
                                       >
                                         <Social__StyledIcon
                                           as={[Function]}
@@ -1003,10 +1009,12 @@ exports[`DocsLayout renders correctly 1`] = `
                                 </Social__SocialLink>
                                 <Social__SocialLink
                                   href="https://medium.com/styled-components"
+                                  isExternal={true}
                                 >
                                   <Link
                                     className="c18"
                                     href="https://medium.com/styled-components"
+                                    isExternal={true}
                                     unstyled={true}
                                   >
                                     <Link
@@ -1015,6 +1023,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                       <a
                                         className="c18"
                                         href="https://medium.com/styled-components"
+                                        target="_blank"
                                       >
                                         <Social__StyledIcon
                                           as={[Function]}
@@ -1291,10 +1300,12 @@ exports[`DocsLayout renders correctly 1`] = `
                                   >
                                     <Social__SocialLink
                                       href="https://spectrum.chat/styled-components/"
+                                      isExternal={true}
                                     >
                                       <Link
                                         className="c18"
                                         href="https://spectrum.chat/styled-components/"
+                                        isExternal={true}
                                         unstyled={true}
                                       >
                                         <Link
@@ -1303,6 +1314,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                           <a
                                             className="c18"
                                             href="https://spectrum.chat/styled-components/"
+                                            target="_blank"
                                           >
                                             <Spectrum>
                                               <Social__Svg
@@ -1332,10 +1344,12 @@ exports[`DocsLayout renders correctly 1`] = `
                                     </Social__SocialLink>
                                     <Social__SocialLink
                                       href="https://github.com/styled-components"
+                                      isExternal={true}
                                     >
                                       <Link
                                         className="c18"
                                         href="https://github.com/styled-components"
+                                        isExternal={true}
                                         unstyled={true}
                                       >
                                         <Link
@@ -1344,6 +1358,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                           <a
                                             className="c18"
                                             href="https://github.com/styled-components"
+                                            target="_blank"
                                           >
                                             <Social__StyledIcon
                                               as={[Function]}
@@ -1365,10 +1380,12 @@ exports[`DocsLayout renders correctly 1`] = `
                                     </Social__SocialLink>
                                     <Social__SocialLink
                                       href="https://medium.com/styled-components"
+                                      isExternal={true}
                                     >
                                       <Link
                                         className="c18"
                                         href="https://medium.com/styled-components"
+                                        isExternal={true}
                                         unstyled={true}
                                       >
                                         <Link
@@ -1377,6 +1394,7 @@ exports[`DocsLayout renders correctly 1`] = `
                                           <a
                                             className="c18"
                                             href="https://medium.com/styled-components"
+                                            target="_blank"
                                           >
                                             <Social__StyledIcon
                                               as={[Function]}


### PR DESCRIPTION
Added target _blank on external links for improve user experience and accesibility.
This way the user will not leave the website after clicking on a social media link, thus improving their experience.