### PR TITLE
clarify typescript documentation examples for react-native

### DIFF
--- a/sections/api/typescript.md
+++ b/sections/api/typescript.md
@@ -46,6 +46,8 @@ declare module 'styled-components' {
 React-Native:
 
 ```ts
+import 'styled-components/native'
+
 declare module 'styled-components/native' {
   export interface DefaultTheme {
     borderRadius: string;
@@ -85,14 +87,13 @@ React-Native:
 ```jsx
 // styled-components.ts
 import * as styledComponents from "styled-components/native";
-
-import ThemeInterface from "./theme";
+import DefaultTheme from "styled-components/native";
 
 const {
   default: styled,
   css,
   ThemeProvider
-} = styledComponents as styledComponents.ReactNativeThemedStyledComponentsModule<ThemeInterface>;
+} = styledComponents as styledComponents.ReactNativeThemedStyledComponentsModule<DefaultTheme>;
 
 export { css, ThemeProvider };
 export default styled;

--- a/sections/api/typescript.md
+++ b/sections/api/typescript.md
@@ -82,23 +82,6 @@ const myTheme: DefaultTheme = {
 export { myTheme };
 ```
 
-React-Native:
-
-```jsx
-// styled-components.ts
-import * as styledComponents from "styled-components/native";
-import DefaultTheme from "styled-components/native";
-
-const {
-  default: styled,
-  css,
-  ThemeProvider
-} = styledComponents as styledComponents.ReactNativeThemedStyledComponentsModule<DefaultTheme>;
-
-export { css, ThemeProvider };
-export default styled;
-```
-
 ### Styling components
 
 That's it! We're able to use styled-components just by using any original import.


### PR DESCRIPTION
Remove some confusion around the code snippets for setting up the theme interface with React-Native:

- Add missing import for the declaration merging example
- ~~Replace the `ThemeInterface` import with the `DefaultTheme` that was augmented in the previous step. The `ThemeInterface` and the `theme.ts` file from which it is imported are never mentioned before this step.~~
- Remove unnecessary code snippet 