### PR TITLE
Fix attrs examples

### DIFF
--- a/sections/api/primary/styled-component.mdx
+++ b/sections/api/primary/styled-component.mdx
@@ -47,10 +47,10 @@ Returns another `StyledComponent`.
 ```react
 // import styled from 'styled-components'
 
-const Input = styled.input.attrs(props => ({
+const Input = styled.input.attrs<{ $padding?: string; $small?: boolean; }>(props => ({
   type: 'text',
   size: props.$small ? 5 : undefined,
-}))<{ $padding?: string; $small?: boolean; }>`
+}))`
   border-radius: 3px;
   border: 1px solid #BF4F74;
   display: block;

--- a/sections/basics/attaching-additional-props.mdx
+++ b/sections/basics/attaching-additional-props.mdx
@@ -45,7 +45,7 @@ This allows each wrapper to **override** nested uses of `.attrs`, similarly to h
 const Input = styled.input.attrs(props => ({
   type: "text",
   $size: props.$size || "1em",
-})<{ $size?: string; }>`
+}))<{ $size?: string; }>`
   border: 2px solid #BF4F74;
   margin: ${props => props.$size};
   padding: ${props => props.$size};

--- a/sections/basics/attaching-additional-props.mdx
+++ b/sections/basics/attaching-additional-props.mdx
@@ -7,13 +7,13 @@ This way you can for example attach static props to an element, or pass a third-
 Here we render an `Input` component and attach some dynamic and static attributes to it:
 
 ```react
-const Input = styled.input.attrs(props => ({
+const Input = styled.input.attrs<{ $size?: string; }>(props => ({
   // we can define static props
   type: "text",
 
   // or we can define dynamic ones
   $size: props.$size || "1em",
-}))<{ $size?: string; }>`
+}))`
   color: #BF4F74;
   font-size: 1em;
   border: 2px solid #BF4F74;
@@ -42,10 +42,10 @@ This allows each wrapper to **override** nested uses of `.attrs`, similarly to h
 
 `Input`'s `.attrs` are applied first, and then `PasswordInput`'s `.attrs`:
 ```react
-const Input = styled.input.attrs(props => ({
+const Input = styled.input.attrs<{ $size?: string; }>(props => ({
   type: "text",
   $size: props.$size || "1em",
-}))<{ $size?: string; }>`
+}))`
   border: 2px solid #BF4F74;
   margin: ${props => props.$size};
   padding: ${props => props.$size};


### PR DESCRIPTION
I noticed a few minor things with the `.attrs` examples in the docs.

First, fixed a tiny syntax error in the example [here](https://styled-components.com/docs/basics#overriding-.attrs) that caused an error to show up in the page:
![image](https://github.com/styled-components/styled-components-website/assets/30258875/1a132373-e5dd-48e6-bd02-944370f93493)

Next, the generic type parameters seem to be in the wrong position, as the examples all give me type errors when I copy them (SC 6.0.2 & TS 5.1.6):
![image](https://github.com/styled-components/styled-components-website/assets/30258875/03a30102-880d-4a86-b506-e33ea94f14ff)
I could easily be wrong here as I was actually looking at the docs for examples of correct generics with `.attrs` 😅, but moving the param seems to resolve the error and the props still get typed properly when using the attr-wrapped component.