### PR TITLE
Default installation as a dev dependency

### DIFF
--- a/sections/basics/installation.mdx
+++ b/sections/basics/installation.mdx
@@ -4,10 +4,10 @@ Installing styled-components only takes a single command and you're ready to rol
 
 ```
 # with npm
-npm install styled-components
+npm install --save-dev styled-components
 
 # with yarn
-yarn add styled-components
+yarn add --dev styled-components
 ```
 
 If you use a package manager like [yarn](https://yarnpkg.com/) that supports the "resolutions" package.json field, we also highly recommend you add an entry to it as well corresponding to the major version range. This helps avoid an entire class of problems that arise from multiple versions of styled-components being installed in your project.


### PR DESCRIPTION
The reason behind it is to make the default what's likely the most used way to install the library. It'll help reducing the overhead for library creators of [manually doing it afterwards](https://styled-components.com/docs/faqs#marking-styled-components-as-external-in-your-package-dependencies).