### PR TITLE
Update v6 migration guide for shouldForwardProp

### DIFF
--- a/sections/faqs/migration-v6.mdx
+++ b/sections/faqs/migration-v6.mdx
@@ -34,10 +34,20 @@ import { StyleSheetManager } from 'styled-components';
 
 function MyApp() {
     return (
-        <StyleSheetManager shouldForwardProp={isPropValid}>
+        <StyleSheetManager shouldForwardProp={shouldForwardProp}>
             {/* other providers or your application's JSX */}
         </StyleSheetManager>
     )
+}
+
+// This implements the default behavior from styled-components v5
+function shouldForwardProp(propName, target) {
+  if (typeof target === "string") {
+    // For HTML elements, forward the prop if it is a valid HTML attribute
+    return isPropValid(propName);
+  }
+  // For other elements, forward all props
+  return true;
 }
 ```
 

--- a/sections/faqs/migration-v6.mdx
+++ b/sections/faqs/migration-v6.mdx
@@ -26,7 +26,7 @@ However, if you don't use TypeScript in your project, don't worry! IDEs like VS 
 
 ### `shouldForwardProp` is no longer provided by default
 
-If haven't migrated your styling to use [transient props (`$prefix`)](/docs/faqs#transient-props-since-51), you might notice React warnings about styling props getting through to the DOM in v6. To restore the v5 behavior, use `StyleSheetManager`:
+If haven't migrated your styling to use [transient props (`$prefix`)](/docs/faqs#transient-props-since-5.1), you might notice React warnings about styling props getting through to the DOM in v6. To restore the v5 behavior, use `StyleSheetManager`:
 
 ```tsx
 import isPropValid from '@emotion/is-prop-valid';

--- a/sections/faqs/migration-v6.mdx
+++ b/sections/faqs/migration-v6.mdx
@@ -42,12 +42,12 @@ function MyApp() {
 
 // This implements the default behavior from styled-components v5
 function shouldForwardProp(propName, target) {
-  if (typeof target === "string") {
-    // For HTML elements, forward the prop if it is a valid HTML attribute
-    return isPropValid(propName);
-  }
-  // For other elements, forward all props
-  return true;
+    if (typeof target === "string") {
+        // For HTML elements, forward the prop if it is a valid HTML attribute
+        return isPropValid(propName);
+    }
+    // For other elements, forward all props
+    return true;
 }
 ```
 


### PR DESCRIPTION
In v5, prop forwarding behaved differently depending on if the target was an HTML element, or a React Component.  

This PR updates the code example showing how to re-implement the default behavior that existed in v5 in a way that more closely matches the v5 behavior. 