### PR TITLE
fixed example for styled components 6 types

### DIFF
--- a/sections/api/primary/styled-component.mdx
+++ b/sections/api/primary/styled-component.mdx
@@ -47,10 +47,10 @@ Returns another `StyledComponent`.
 ```react
 // import styled from 'styled-components'
 
-const Input = styled.input.attrs(props => ({
+const Input = styled.input.attrs<{ $padding?: string; $small?: boolean; }>(props => ({
   type: 'text',
   size: props.$small ? 5 : undefined,
-}))<{ $padding?: string; $small?: boolean; }>`
+}))`
   border-radius: 3px;
   border: 1px solid #BF4F74;
   display: block;


### PR DESCRIPTION
this fixes a compilation error in the example. the generic parameter must be set on the `attrs` function so its parameter's function parameter gets the correct type and props are accessible without type error.