### PR TITLE
Improved accessibility in Slider/Navigation.tsx and UserLogos/index.tsx

### DIFF
--- a/components/Slider/Navigation.tsx
+++ b/components/Slider/Navigation.tsx
@@ -16,7 +16,7 @@ export default function Navigation({ prev, next }: NavigationProps) {
   return (
     <SlideNav>
       <ShowcaseLink item={prev}>
-        <NavButton>
+        <NavButton role="button" tabIndex={0} aria-label="previous showcase use left arrow">
           <Image
             width={1920}
             height={1080}
@@ -37,7 +37,7 @@ export default function Navigation({ prev, next }: NavigationProps) {
       </ShowcaseLink>
 
       <ShowcaseLink item={next}>
-        <NavButton>
+        <NavButton role="button" tabIndex={0} aria-label="next showcase use right arrow">
           <Image
             width={1920}
             height={1080}

--- a/components/Slider/Navigation.tsx
+++ b/components/Slider/Navigation.tsx
@@ -16,7 +16,7 @@ export default function Navigation({ prev, next }: NavigationProps) {
   return (
     <SlideNav>
       <ShowcaseLink item={prev}>
-        <NavButton role="button" tabIndex={0} aria-label="previous showcase use left arrow">
+        <NavButton role="button" tabIndex={0} aria-label="previous showcase, use left arrow to navigate">
           <Image
             width={1920}
             height={1080}
@@ -37,7 +37,7 @@ export default function Navigation({ prev, next }: NavigationProps) {
       </ShowcaseLink>
 
       <ShowcaseLink item={next}>
-        <NavButton role="button" tabIndex={0} aria-label="next showcase use right arrow">
+        <NavButton role="button" tabIndex={0} aria-label="next showcase, use right arrow to navigate">
           <Image
             width={1920}
             height={1080}

--- a/components/UsersLogos/index.tsx
+++ b/components/UsersLogos/index.tsx
@@ -1,5 +1,6 @@
 import { Company } from 'companies-manifest';
 import styled, { keyframes } from 'styled-components';
+import { useState } from 'react';
 
 const getSlide = (childIndex: number, reverse?: boolean) => keyframes`
   from {
@@ -32,6 +33,7 @@ const UsersSlider = styled.span<{ $offset?: number; $reverse?: boolean }>`
   white-space: nowrap;
   overflow: hidden;
   position: absolute;
+  cursor: pointer; // Add cursor pointer to indicate it's clickable
 
   ${UsersWrapper} {
     flex-direction: ${({ $reverse }) => ($reverse ? 'row' : 'row-reverse')};
@@ -80,15 +82,38 @@ const SortedLogos = ({ users }: ISortedLogos) => (
 );
 
 const UsersLogos = ({ users, reverse }: { reverse?: boolean; users: ISortedLogos['users'] }) => {
+  // State to track animation pause
+  const [animationPaused, setAnimationPaused] = useState(false);
+
+  // Function to toggle animation pause state
+  const toggleAnimation = () => {
+    setAnimationPaused(prevState => !prevState);
+  };
+
   return (
     <UsersSliderContainer>
-      <UsersSlider $offset={-1} $reverse={reverse}>
+      <UsersSlider
+        $offset={-1}
+        $reverse={reverse}
+        onClick={toggleAnimation} // Attach click event handler
+        style={{ animationPlayState: animationPaused ? 'paused' : 'running' }} // Apply animationPlayState style
+      >
         <SortedLogos users={users} />
       </UsersSlider>
-      <UsersSlider $offset={0} $reverse={reverse}>
+      <UsersSlider
+        $offset={0}
+        $reverse={reverse}
+        onClick={toggleAnimation} // Attach click event handler
+        style={{ animationPlayState: animationPaused ? 'paused' : 'running' }} // Apply animationPlayState style
+      >
         <SortedLogos users={users} />
       </UsersSlider>
-      <UsersSlider $offset={1} $reverse={reverse}>
+      <UsersSlider
+        $offset={1}
+        $reverse={reverse}
+        onClick={toggleAnimation} // Attach click event handler
+        style={{ animationPlayState: animationPaused ? 'paused' : 'running' }} // Apply animationPlayState style
+      >
         <SortedLogos users={users} />
       </UsersSlider>
     </UsersSliderContainer>


### PR DESCRIPTION
## Addressing Issue #904 - Enhance Accessibility 
- On the Showcase page, users were unable to access the left and right slider navigators for displaying the previous and next company showcases. These navigators rely on left and right arrow keys for interaction.

- I've added HTML attributes that allow users to tab to these sections of the page, and I've provided clear instructions for navigation. Although these elements are buttons, the instruction "use left/right arrow to navigate" should suffice for users with impairments.

Here is the change visualized. Changes were made in Slider/Navigation.tsx. 

https://github.com/styled-components/styled-components-website/assets/51212933/6d662adf-97f2-4585-9f5b-453c46a47b56

## Addressing Issue #769 - Pause Logo Scrolling Animation
- This issue suggested allowing users to 'pause' scrolling animated content in compliance with [WCAG 2.1 Criterion 2.2.2: Pause, Stop, Hide](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html). Here's how I resolved it:

- I implemented a simple solution using React's `useState` hook, which identifies the current state of the moving content 'UserLogos'. Users can now click the container to toggle the CSS `animationPlayState` property between 'paused' and 'running'. Additionally, I've added a pointer cursor to the logo section to indicate that it's a clickable field.

Here is the change visualized. Changes were made in UserLogos/index.tsx. 

https://github.com/styled-components/styled-components-website/assets/51212933/ac0b273e-e212-4a21-a3cd-d7fe34277642





