### PR TITLE
fixed visual syntax error for basics#attaching-additional-props

### DIFF
--- a/sections/basics/attaching-additional-props.mdx
+++ b/sections/basics/attaching-additional-props.mdx
@@ -45,7 +45,7 @@ This allows each wrapper to **override** nested uses of `.attrs`, similarly to h
 const Input = styled.input.attrs(props => ({
   type: "text",
   $size: props.$size || "1em",
-})<{ $size?: string; }>`
+}))<{ $size?: string; }>`
   border: 2px solid #BF4F74;
   margin: ${props => props.$size};
   padding: ${props => props.$size};


### PR DESCRIPTION
Fixed visual syntax error that failed to show the correct inputs for the docs/basics#attaching-additional-props page.

This is what the page looks live:
<img width="536" alt="error" src="https://github.com/styled-components/styled-components-website/assets/20734465/a0db1660-c6e5-47dd-a40d-36cbf467d207">

There is now no syntax error, and the desired input fields are displayed on the page:
<img width="756" alt="image" src="https://github.com/styled-components/styled-components-website/assets/20734465/2c73ccbe-d6be-4560-8569-7e82e7fdc095">
