### PR TITLE
docs: update the css-prop installation guide for users using v6

### DIFF
--- a/sections/api/primary/css-prop.mdx
+++ b/sections/api/primary/css-prop.mdx
@@ -63,4 +63,19 @@ To prevent TypeScript errors on the `css` prop on arbitrary elements, install `@
 ```ts
 import {} from 'styled-components/cssprop'
 ```
+
 See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31245#issuecomment-446011384 for more information.
+
+If you're using a higher version than v6, you do not need to install `@types/styled-components`. 
+Instead, you can directly import the `CSSProp` in your project like this:
+
+```ts
+import {} from 'react'
+import type { CSSProp } from 'styled-components'
+
+declare module 'react' {
+  interface Attributes {
+    css?: CSSProp | undefined
+  }
+}
+```


### PR DESCRIPTION
This PR updates the `css-prop` API reference's [Usage with TypeScript section](https://styled-components.com/docs/api#usage-with-typescript) to inform readers using higher versions than `styled components` v6 that they can simply import the `CssProp` type from the `styled-component` package rather than installing a separate types package from [Definitely Typed](https://github.com/DefinitelyTyped/DefinitelyTyped).

Here is the updated version of the CSS Prop section: https://styled-components-ns1cyl5l8-styledcomponents.vercel.app/docs/api#usage-with-typescript