### PR TITLE
fix: broken links in Ecosystem page sidebar

### DIFF
--- a/components/Nav/SidebarMenus.tsx
+++ b/components/Nav/SidebarMenus.tsx
@@ -8,7 +8,7 @@ import Link, { StyledLink } from '../Link';
 const { pages } = json;
 
 export interface SimpleSidebarMenuProps {
-  pages?: { title: string; pathname: string; sections: { title: string }[]; href: string }[];
+  pages?: { title: string; pathname?: string; sections: { title: string }[]; href: string }[];
 }
 
 export const SimpleSidebarMenu = ({ pages = [] }: SimpleSidebarMenuProps) => {
@@ -91,6 +91,6 @@ export const DocsSidebarMenu = (props: DocsSidebarMenuProps) => {
   );
 };
 
-function getSectionPath(parentPathname: string, title: string) {
-  return `${parentPathname}#${titleToDash(title)}`;
+function getSectionPath(parentPathname: string | undefined, title: string) {
+  return `${parentPathname ?? ''}#${titleToDash(title)}`;
 }


### PR DESCRIPTION
This fixes broken links for the "Built with styled-components" and "Further Reading" subsections in the sidebar menu of the [Ecosystem](https://styled-components.com/ecosystem) page

![image](https://github.com/user-attachments/assets/273cc6d8-e493-4014-bcba-e2cdb795d10f)
