### PR TITLE
docs: fix typo migration-v6.mdx

### DIFF
--- a/sections/faqs/migration-v6.mdx
+++ b/sections/faqs/migration-v6.mdx
@@ -26,7 +26,7 @@ However, if you don't use TypeScript in your project, don't worry! IDEs like VS 
 
 ### `shouldForwardProp` is no longer provided by default
 
-If haven't migrated your styling to use [transient props (`$prefix`)](/docs/faqs#transient-props-since-5.1), you might notice React warnings about styling props getting through to the DOM in v6. To restore the v5 behavior, use `StyleSheetManager`:
+If you haven't migrated your styling to use [transient props (`$prefix`)](/docs/faqs#transient-props-since-5.1), you might notice React warnings about styling props getting through to the DOM in v6. To restore the v5 behavior, use `StyleSheetManager`:
 
 ```tsx
 import isPropValid from '@emotion/is-prop-valid';


### PR DESCRIPTION
Fix very small typo in the doc
If haven't -> If you haven't